### PR TITLE
finetuning: Fix quoting issue in command and buildenv_command.

### DIFF
--- a/elbepack/asciidoclog.py
+++ b/elbepack/asciidoclog.py
@@ -55,10 +55,18 @@ class LogBase(object):
         self.printo( "------------------------------------------------------------------------------" )
         self.printo()
 
-    def do(self, cmd, allow_fail=False):
+    def do(self, cmd, allow_fail=False, input=None):
 
         self.printo( "running cmd +%s+" % cmd )
-        ret, output = command_out(cmd)
+        if input is not None:
+            self.printo( "Sending on STDIN:")
+            self.verbatim_start()
+            if input.endswith(('\n', '\r')):
+                self.print_raw(input)
+            else:
+                self.print_raw(input + "\n")
+            self.verbatim_end()
+        ret, output = command_out(cmd, input=input)
 
         if len(output) != 0:
             self.verbatim_start()

--- a/elbepack/finetuning.py
+++ b/elbepack/finetuning.py
@@ -222,7 +222,7 @@ class CmdAction(FinetuningAction):
 
     def execute(self, log, buildenv, target):
         with target:
-            log.chroot (target.path, "/bin/sh -c '%s'" % self.node.et.text)
+            log.chroot (target.path, "/bin/sh", input=self.node.et.text)
 
 FinetuningAction.register( CmdAction )
 
@@ -235,7 +235,7 @@ class BuildenvCmdAction(FinetuningAction):
 
     def execute(self, log, buildenv, target):
         with buildenv:
-            log.chroot (buildenv.path, "/bin/sh -c '%s'" % self.node.et.text)
+            log.chroot (buildenv.path, "/bin/sh", input=self.node.et.text)
 
 FinetuningAction.register( BuildenvCmdAction )
 

--- a/elbepack/shellhelper.py
+++ b/elbepack/shellhelper.py
@@ -37,15 +37,23 @@ def system(cmd, allow_fail=False):
             raise CommandError(cmd, p.returncode)
 
 
-def command_out(cmd):
-    p = Popen(cmd, shell=True, stdout=PIPE, stderr=STDOUT )
-    output, stderr = p.communicate()
+def command_out(cmd, input=None):
+    if input is None:
+        p = Popen(cmd, shell=True, stdout=PIPE, stderr=STDOUT )
+        output, stderr = p.communicate()
+    else:
+        p = Popen(cmd, shell=True, stdout=PIPE, stderr=STDOUT, stdin=PIPE)
+        output, stderr = p.communicate(input=input)
 
     return p.returncode, output
 
-def command_out_stderr(cmd):
-    p = Popen(cmd, shell=True, stdout=PIPE, stderr=PIPE )
-    output, stderr = p.communicate()
+def command_out_stderr(cmd, input=None):
+    if input is None:
+        p = Popen(cmd, shell=True, stdout=PIPE, stderr=PIPE )
+        output, stderr = p.communicate()
+    else:
+        p = Popen(cmd, shell=True, stdout=PIPE, stderr=PIPE, stdin=PIPE)
+        output, stderr = p.communicate(input=input)
 
     return p.returncode, output, stderr
 


### PR DESCRIPTION
Using quotes in command is not possible, because ' quotes were used to pass the command to /bin/sh. This is problematic if the command itself requires nested quotes.

To fix this the command is not passed as an commandline string but piped into the chrooted /bin/sh.
