### PR TITLE
dockerfile: change name of maintainer

### DIFF
--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -4,7 +4,7 @@
 FROM debian:wheezy
 
 # Maintainer
-MAINTAINER Silvio Fricke <silvio.fricke@gmail.com>
+# MAINTAINER forename surename <your.mail@address.com>
 
 # set debian/ubuntu config environment to noninteractive
 ENV DEBIAN_FRONTEND noninteractive

--- a/dockerfile/README.md
+++ b/dockerfile/README.md
@@ -19,6 +19,9 @@ You need docker installed and a running docker service.
 
 ## Build image
 
+Please add a `MAINTAINER` entry in the dockerfile and start the buildprocess
+with
+
     % cd dockerfile
     % docker build -t own-elbe-system .
 


### PR DESCRIPTION
hey @manut, please pull this branch. I had my name as Maintainer in the dockerfile. All generated images belongs now to me :-)
With `docker history <imagename>` you can get the Maintainer of a image.
