### PR TITLE
fix setting of password in adduser finetuning command.

### DIFF
--- a/elbepack/finetuning.py
+++ b/elbepack/finetuning.py
@@ -190,7 +190,7 @@ class AddUserAction(FinetuningAction):
           log.chroot (target.path, "/usr/sbin/useradd -U -m -s %s %s" % (
                 self.node.et.attrib['shell'], self.node.et.text))
 
-        log.chroot (target.path, "/bin/sh -c 'echo %s\n%s\n | passwd %s" % (
+        log.chroot (target.path, "/bin/sh -c 'echo %s\n%s\n | passwd %s'" % (
                            self.node.et.attrib['passwd'],
                            self.node.et.attrib['passwd'],
                            self.node.et.text))


### PR DESCRIPTION
setting password in adduser fuinetuning-command fails due to quote missmatch.
