### PR TITLE
use arch from XML or program argument instead of hardwired value

### DIFF
--- a/elbepack/commands/init.py
+++ b/elbepack/commands/init.py
@@ -153,7 +153,7 @@ def run_command( argv ):
         os.putenv ("no_proxy", "localhost,127.0.0.1")
 
     try:
-        copy_kinitrd(xml.node("/initvm"), out_path, defs, arch="amd64")
+        copy_kinitrd(xml.node("/initvm"), out_path, defs, arch=buildtype)
     except NoKinitrdException as e:
         print "Failure to download kernel/initrd debian Package:"
         print


### PR DESCRIPTION
Fixes #110 
A call to copy_kinitrd in elbepack/commands/init.py is made with the value of the "arch" argument hardwired to "amd64", however, both XML file and program arguments allow specifying other architectures as well. This patch enables setting the arch argument and thus creating the initvm on architectures other than amd64 (tested on i386).

In order for this patch to work, two packages need to be made available for all the supported architectures (preferably in the http://debian.linutronix.de/elbe-common repository):

1. elbe-bootstrap
2. qemu-elbe-user-static

The latter contains only the static version of the qemu binary compiled for the arm architecture. Its usefulness on architectures other than arm is doubtful. Perhaps elbepack/init/preseed.cfg.mako should be patched accordingly?