### PR TITLE
docker: fix build in case of configuration file conflicts in dpkg

### DIFF
--- a/contrib/dockerfile/Dockerfile.in
+++ b/contrib/dockerfile/Dockerfile.in
@@ -19,6 +19,7 @@ RUN echo "deb http://ftp.de.debian.org/debian stretch main" > /etc/apt/sources.l
 RUN export DEBIAN_FRONTEND noninteractive ;\
     apt-get update -y ;\
     apt-get install -y --no-install-recommends \
+                    -o Dpkg::Options::="--force-confnew" \
         systemd \
         ca-certificates \
         sudo \


### PR DESCRIPTION
When running 'make build' for building the docker container, the
process stops with this message:

Errors were encountered while processing:
 systemd
E: Sub-process /usr/bin/dpkg returned an error code (1)
The command [...] returned a non-zero code: 100
Makefile:14: recipe for target 'build' failed
make: *** [build] Error 100

This is because there is a conflict in some configuration file
between the base container and the new version of systemd.

To fix this we tell dpkg to apply the new configuration file
and drop the old one.

This is probably only necessary for versions <= v2.9.13. In the
v3.0 development branch the base image has been replaced and it
does not show the conflict.

Signed-off-by: Frieder Schrempf <frieder.schrempf@kontron.de>