### PR TITLE
noauth for a single repo as attribute to a url element

### DIFF
--- a/elbepack/elbexml.py
+++ b/elbepack/elbexml.py
@@ -163,11 +163,14 @@ class ElbeXML(object):
 
             if self.prj.has("mirror/url-list"):
                 for url in self.prj.node("mirror/url-list"):
+                    noauth_url = ""
+                    if url.bool_attr("noauth") and noauth is "":
+                        noauth_url = "[trusted=yes] "
                     if url.has("binary"):
-                        mirror += "deb " + noauth + \
+                        mirror += "deb " + noauth + noauth_url + \
                                    url.text("binary").strip() + "\n"
                     if url.has("source"):
-                        mirror += "deb-src " + noauth + \
+                        mirror += "deb-src " + noauth + noauth_url + \
                             url.text("source").strip() + "\n"
 
         if self.prj.has("mirror/cdrom"):

--- a/elbepack/pbuilder.py
+++ b/elbepack/pbuilder.py
@@ -136,11 +136,14 @@ def pbuilder_write_repo_hook(builddir, xml):
             if xml.prj.has("noauth"):
                 noauth = "[trusted=yes] "
             for url in xml.prj.node("mirror/url-list"):
+                noauth_url = ""
+                if url.bool_attr("noauth") and noauth is "":
+                    noauth_url = "[trusted=yes] "
                 if url.has("binary"):
-                    mirror += 'echo "deb ' + noauth + \
+                    mirror += 'echo "deb ' + noauth + noauth_url + \
                               url.text("binary").strip() + \
                               '" >> /etc/apt/sources.list\n'
-                if url.has("raw-key") and not xml.prj.has("noauth"):
+                if url.has("raw-key") and not xml.prj.has("noauth") and not url.bool_attr("noauth"):
                     key = "\n".join(line.strip(" \t") for line in url.text('raw-key').splitlines()[1:-1])
                     mirror = mirror_script_add_key_text(mirror, key)
 

--- a/elbepack/pkgutils.py
+++ b/elbepack/pkgutils.py
@@ -35,12 +35,15 @@ def get_sources_list(prj):
 
     if prj.node("mirror/url-list"):
         for n in prj.node("mirror/url-list"):
+            noauth_url = ""
+            if n.bool_attr("noauth"):
+                noauth_url = "[trusted=yes] "
             if n.has("binary"):
                 tmp = n.text("binary").replace("LOCALMACHINE", "10.0.2.2")
-                slist += "deb %s\n" % tmp.strip()
+                slist += "deb %s\n" % noauth_url + tmp.strip()
             if n.has("source"):
                 tmp = n.text("source").replace("LOCALMACHINE", "10.0.2.2")
-                slist += "deb-src %s\n" % tmp.strip()
+                slist += "deb-src %s\n" % noauth_url + tmp.strip()
 
     return slist
 

--- a/elbepack/rfs.py
+++ b/elbepack/rfs.py
@@ -283,14 +283,8 @@ class BuildEnv (object):
 
     def import_keys(self):
         if self.xml.has('project/mirror/url-list'):
-            # Should we use self.xml.prj.has("noauth")???
-            #
-            # If so, this is related to issue #220 -
-            # https://github.com/Linutronix/elbe/issues/220
-            #
-            # I could make a none global 'noauth' flag for mirrors
             for url in self.xml.node('project/mirror/url-list'):
-                if url.has('raw-key'):
+                if url.has('raw-key') and not url.bool_attr("noauth"):
                     key = "\n".join(line.strip(" \t") for line in url.text('raw-key').splitlines()[1:-1])
                     self.add_key(key)
 

--- a/elbepack/virtapt.py
+++ b/elbepack/virtapt.py
@@ -161,14 +161,8 @@ class VirtApt(object):
 
     def import_keys(self):
         if self.xml.has('project/mirror/url-list'):
-            # Should we use self.xml.prj.has("noauth")???
-            #
-            # If so, this is related to issue #220 -
-            # https://github.com/Linutronix/elbe/issues/220
-            #
-            # I could make a none global 'noauth' flag for mirrors
             for url in self.xml.node('project/mirror/url-list'):
-                if url.has('raw-key'):
+                if url.has('raw-key') and not url.bool_attr("noauth"):
                     key = "\n".join(line.strip(" \t") for line in url.text('raw-key').splitlines()[1:-1])
                     self.add_key(key)
 

--- a/schema/dbsfed.xsd
+++ b/schema/dbsfed.xsd
@@ -200,6 +200,13 @@
       </element>
     </all>
     <attribute ref="xml:base"/>
+    <attribute name="noauth" type="boolean" use="optional">
+      <annotation>
+        <documentation>
+          Allow installation of unsigned debian packages from this repo url(s).
+        </documentation>
+      </annotation>
+    </attribute>
   </complexType>
 
   <complexType name="url-list">


### PR DESCRIPTION
Dear devs,

for improved security it should be possible to allow the noauth tag also on a single url element if a unsigned repo is used.

I´ve implemented this for the v8 release, but this patches applies also cleanly on master.

What is your suggestion about this security improvement?

Note: This impl does not break the old noauth impl.

Greets