### PR TITLE
command init: don't use user's gnupg configuration file

### DIFF
--- a/elbepack/commands/init.py
+++ b/elbepack/commands/init.py
@@ -230,10 +230,10 @@ def run_command(argv):
         for key in xml.all(".//initvm/mirror/url-list/url/raw-key"):
             keys.append(key.et.text)
         import_keyring = os.path.join(out_path, "elbe-keyring")
-        command_out('gpg --no-default-keyring --keyring %s --import' % import_keyring,
+        command_out('gpg --no-options --no-default-keyring --keyring %s --import' % import_keyring,
                     stdin="".join(keys))
         export_keyring = import_keyring + ".gpg"
-        command_out('gpg --no-default-keyring --keyring %s --export --output %s' % (import_keyring,
+        command_out('gpg --no-options --no-default-keyring --keyring %s --export --output %s' % (import_keyring,
                                                                                     export_keyring))
 
     if opt.devel:


### PR DESCRIPTION
if user's gnupg configuration file contained options to include
other keyrings, then 'elbe-keyring' wasn't created at all

gpg error message if gnupg conf has keyring option:
gpg: keyblock resource
'.../elbe/initvm/.elbe-in/elbe-keyring':
No such file or directory
gpg: key 0x36AA35FF22BB8F84: 1 signature not checked due to a missing key
gpg: no writable keyring found: Not found
gpg: error reading '[stdin]': General error
gpg: import from '[stdin]' failed: General error
gpg: Total number processed: 0

Because of that resulting 'elbe-keyring.gpg' didn't had any
PGP keys specified in initvm.xml file.

Another problem is that without '--no-options' keys from other
user-defined keyrings leaked into resulting elbe-keyring.gpg installed
into build vm.

Closes #233

Signed-off-by: Andrey Skvortsov <andrej.skvortzov@gmail.com>