### PR TITLE
debianize: u-boot: Add dependencies required for cross compilation

### DIFF
--- a/elbepack/makofiles/debianize/u-boot/control.mako
+++ b/elbepack/makofiles/debianize/u-boot/control.mako
@@ -7,7 +7,14 @@ Source: u-boot-${p_name}-${k_version}
 Section: admin
 Priority: optional
 Maintainer: ${m_name} <${m_mail}>
-Build-Depends: debhelper (>= 9), bc
+Build-Depends:
+ debhelper (>= 9),
+ bc,
+ bison,
+ device-tree-compiler,
+ debhelper,
+ flex,
+ lzop:native,
 Standards-Version: 3.8.4
 Homepage: http://www.denx.de/wiki/U-Boot/
 


### PR DESCRIPTION
Complete the list of u-boot build dependencies so it can also be cross-compiled using `dpkg-buildpackage -a ${p_arch} -us -uc`.