### PR TITLE
Post-install, pre-rm fixes for the renamed package python3-elbe-updated

### DIFF
--- a/debian/python3-elbe-updated.postinst
+++ b/debian/python3-elbe-updated.postinst
@@ -8,5 +8,5 @@ set -e
 #  elbe-updated is updating itself
 
 if which pycompile >/dev/null 2>&1; then
-	pycompile -p elbe-updated 
+	pycompile -p python3-elbe-updated 
 fi

--- a/debian/python3-elbe-updated.prerm
+++ b/debian/python3-elbe-updated.prerm
@@ -9,9 +9,9 @@ set -e
 #  elbe-updated is updating itself
 
 if which pyclean >/dev/null 2>&1; then
-	pyclean -p elbe-updated 
+	pyclean -p python3-elbe-updated 
 else
-	dpkg -L elbe-updated | grep \.py$ | while read file
+	dpkg -L python3-elbe-updated | grep \.py$ | while read file
 	do
 		rm -f "${file}"[co] >/dev/null
 	done


### PR DESCRIPTION
The scripts still relied on the old name of the package: elbe-updated, instead of on the new name python3-elbe-updated.  This resulted in a broken package when installing it into the built filesystem