### PR TITLE
Follow symbolic links in init_directories

### DIFF
--- a/elbepack/directories.py
+++ b/elbepack/directories.py
@@ -23,7 +23,7 @@ def init_directories(elbe_relpath):
     global elbe_dir      #pylint: disable=global-statement
     global examples_dir  #pylint: disable=global-statement
 
-    elbe_exe = os.path.abspath(elbe_relpath)
+    elbe_exe = os.path.abspath(os.path.realpath(elbe_relpath))
     elbe_dir = os.path.dirname(elbe_exe)
 
     if elbe_exe.startswith("/usr/bin/"):


### PR DESCRIPTION
Make sure we find the correct base path if elbe is launched using a symbolic link.

Fixes Linutronix#301