### PR TITLE
finetuning: use archive option for CopyFrom/ToPartition

### DIFF
--- a/elbepack/finetuning.py
+++ b/elbepack/finetuning.py
@@ -668,7 +668,7 @@ class CopyFromPartition(ImageFinetuningAction):
                              self.node.et.text, len(fname))
                 raise FinetuningException('Patter matches too many files')
 
-            cmd = 'cp "%s" "%s"' % (fname[0], os.path.join(builddir, aname))
+            cmd = 'cp -av "%s" "%s"' % (fname[0], os.path.join(builddir, aname))
             do(cmd)
 
             target.images.append(aname)
@@ -693,7 +693,7 @@ class CopyToPartition(ImageFinetuningAction):
 
         with ImgMountFilesystem(img_mnt, device) as mnt_fs:
             fname = mnt_fs.fname(self.node.et.text)
-            cmd = 'cp "%s" "%s"' % (os.path.join(builddir, aname), fname)
+            cmd = 'cp -av "%s" "%s"' % (os.path.join(builddir, aname), fname)
             do(cmd)
 
 @FinetuningAction.register('set_partition_type')


### PR DESCRIPTION
All finetuning copy commands use -av except for the project
finetuning commands. There are many situations where the -a
option is necessary (permissions, directories, symlinks,
device nodes).

Use -av for the project finetuning partition copy commands.

Signed-off-by: John Ogness <john.ogness@linutronix.de>
Reviewed-by: Bastian Germann <bage@linutronix.de>