### PR TITLE
Remove duplicated slashes from primary mirror

### DIFF
--- a/elbepack/debinstaller.py
+++ b/elbepack/debinstaller.py
@@ -193,8 +193,9 @@ def get_primary_mirror(prj):
         m = prj.node("mirror")
 
         mirror = m.text("primary_proto") + "://"
-        mirror += m.text("primary_host") + "/"
-        mirror += m.text("primary_path")
+        mirror += "{}/{}".format(m.text("primary_host"),
+                                 m.text("primary_path")
+                                ).replace("//", "/")
     else:
         raise NoKinitrdException("Broken xml file: "
                                  "no cdrom and no primary host")

--- a/elbepack/elbexml.py
+++ b/elbepack/elbexml.py
@@ -120,8 +120,9 @@ class ElbeXML:
             m = self.node("initvm/mirror")
 
             mirror = m.text("primary_proto") + "://"
-            mirror += m.text("primary_host") + "/"
-            mirror += m.text("primary_path")
+            mirror += "{}/{}".format(m.text("primary_host"),
+                                     m.text("primary_path")
+                                    ).replace("//", "/")
 
         elif self.xml.has("initvm/mirror/cdrom") and cdrompath:
             mirror = "file://%s" % cdrompath
@@ -136,8 +137,9 @@ class ElbeXML:
                 mirror = m.text("host")
             else:
                 mirror = m.text("primary_proto") + "://"
-                mirror += m.text("primary_host") + "/"
-                mirror += m.text("primary_path")
+                mirror += "{}/{}".format(m.text("primary_host"),
+                                         m.text("primary_path")
+                                        ).replace("//", "/")
 
         elif self.prj.has("mirror/cdrom") and cdrompath:
             mirror = "file://%s" % cdrompath


### PR DESCRIPTION
This patch removes any duplicated slashes in the primary mirror URL.

This patch fixes #272.

Changes since v1:
* Replace duplicated slashes at all possible places.
* Use str.format() instead of f-strings.

Changes since v2:
* Rebase

Signed-off-by: Daniel Braunwarth <daniel.braunwarth@kuka.com>