### PR TITLE
Extend debootstrap configuration

### DIFF
--- a/elbepack/rfs.py
+++ b/elbepack/rfs.py
@@ -185,19 +185,22 @@ class BuildEnv:
 
         host_arch = get_command_out("dpkg --print-architecture").strip().decode()
 
-        includepkgs = None
-        strapcmd  = 'debootstrap '
-        if self.xml.has("target/debootstrapvariant"):
-            bootstrapvariant = self.xml.text("target/debootstrapvariant")
-            includepkgs = self.xml.node("target/debootstrapvariant").et.get("includepkgs")
-            strapcmd += '--variant="%s" ' % bootstrapvariant
+        strapcmd  = "debootstrap"
 
-        if includepkgs and not "gnupg" in includepkgs.split(','):
-            includepkgs += ",gnupg"
-        if not includepkgs:
-            includepkgs = "gnupg"
+        # Should we use a special bootstrap variant?
+        if self.xml.has("target/debootstrap/variant"):
+            strapcmd += " --variant=%s" % self.xml.text("target/debootstrap/variant")
 
-        strapcmd += ' --include="%s"' % includepkgs
+        # Should we include additional packages into bootstrap?
+        includepkgs = "gnupg"  # These are the packages which are included in any case
+        if self.xml.has("target/debootstrap/include"):
+            includepkgs += ", %s" % self.xml.text("target/debootstrap/include")
+        strapcmd += " --include=\"%s\"" % includepkgs
+
+        # Should we exclude some packages from bootstrap?
+        if self.xml.has("target/debootstrap/exclude"):
+            strapcmd += " --exclude=\"%s\"" % self.xml.text("target/debootstrap/exclude")
+
         keyring = ''
 
         if not self.xml.is_cross(host_arch):

--- a/elbepack/xmlpreprocess.py
+++ b/elbepack/xmlpreprocess.py
@@ -53,6 +53,28 @@ def preprocess_pgp_key(xml):
             raise XMLPreprocessError("Problem with PGP Key URL in <key> tag: %s" %
                                      keyurl)
 
+def preprocess_bootstrap(xml):
+    "Replaces a maybe existing debootstrapvariant element with debootstrap"
+
+    old_node = xml.find(".//debootstrapvariant")
+    if old_node is None:
+        return
+
+    print("[WARN] <debootstrapvariant> is deprecated. Use <debootstrap> instead.")
+
+    bootstrap = Element("debootstrap")
+
+    bootstrap_variant = Element("variant")
+    bootstrap_variant.text = old_node.text
+    bootstrap.append(bootstrap_variant)
+
+    old_includepkgs = old_node.get("includepkgs")
+    if old_includepkgs:
+        bootstrap_include = Element("include")
+        bootstrap_include.text = old_includepkgs
+        bootstrap.append(bootstrap_include)
+
+    old_node.getparent().replace(old_node, bootstrap)
 
 def preprocess_iso_option(xml):
 
@@ -302,6 +324,9 @@ def xmlpreprocess(fname, output, variants=None, proxy=None):
 
         # Change public PGP url key to raw key
         preprocess_pgp_key(xml)
+
+        # Replace old debootstrapvariant with debootstrap
+        preprocess_bootstrap(xml)
 
         preprocess_iso_option(xml)
 

--- a/examples/armhf-ti-beaglebone-black.xml
+++ b/examples/armhf-ti-beaglebone-black.xml
@@ -39,7 +39,9 @@
 		the emulated part (run in QEMU) of the installation
 		significant.
 		-->
-		<debootstrapvariant>minbase</debootstrapvariant>
+		<debootstrap>
+			<variant>minbase</variant>
+		</debootstrap>
 		<package>
 			<!-- build a tarball of the target image -->
 			<tar>

--- a/examples/armhf-ubuntu.xml
+++ b/examples/armhf-ubuntu.xml
@@ -70,7 +70,9 @@
 				<name>image.tgz</name>
 			</tar>
 		</package>
-		<debootstrapvariant>minbase</debootstrapvariant>
+		<debootstrap>
+			<variant>minbase</variant>
+		</debootstrap>
 		<finetuning>
 			<rm>var/cache/apt/archives/*.deb</rm>
 			<rm>/var/cache/apt/*.bin</rm>

--- a/examples/x86_64-docker.xml
+++ b/examples/x86_64-docker.xml
@@ -37,7 +37,9 @@
 		<hostname>debianmin</hostname>
 		<domain>docker</domain>
 		<passwd>docker</passwd>
-		<debootstrapvariant>minbase</debootstrapvariant>
+		<debootstrap>
+			<variant>minbase</variant>
+		</debootstrap>
 		<package>
 			<tar>
 				<name>docker-debianmin.tgz</name>

--- a/examples/x86_64-pc-hdimg-grub-hybrid-buster.xml
+++ b/examples/x86_64-pc-hdimg-grub-hybrid-buster.xml
@@ -31,7 +31,9 @@
 		<domain>tec.linutronix.de</domain>
 		<passwd>foo</passwd>
 		<console>ttyS0,115200</console>
-		<debootstrapvariant variant="sysv">minbase</debootstrapvariant>
+		<debootstrap variant"sysv">
+			<variant>minbase</variant>
+		</debootstrap>
 		<package>
 			<tar>
 				<name>grub-hybrid-rfs.tgz</name>

--- a/schema/dbsfed.xsd
+++ b/schema/dbsfed.xsd
@@ -979,18 +979,10 @@
           </documentation>
         </annotation>
       </element>
-      <element name="debootstrapvariant" type="rfs:debootstrapvarianttype" minOccurs="0" maxOccurs="1">
+      <element name="debootstrap" type="rfs:debootstrap" minOccurs="0" maxOccurs="1">
         <annotation>
           <documentation>
-	    Name of the bootstrap script variant to use. Currently, the
-	    variants supported are minbase, which only includes essential
-	    packages and apt; buildd, which installs the buildessential
-	    packages into TARGET; and fakechroot, which installs the packages
-	    without root privileges. The default, with no --variant=X
-	    argument, is to create a base Debian installation in TARGET.
-            Some documentation mentioned the variant scratchbox too, but this
-	    variant is not supported by the debootstrap used and therefore
-	    not allowed.
+            Bootstrap configuration
           </documentation>
         </annotation>
       </element>
@@ -1099,39 +1091,51 @@
     <attribute ref="xml:base"/>
   </complexType>
 
-  <complexType name="debootstrapvarianttype">
+  <complexType name="debootstrap">
     <annotation>
       <documentation>
-        Enhanced restriction type specifying debootstrap variants.
+        Container for debootstrap configuration.
       </documentation>
     </annotation>
-    <simpleContent>
-      <extension base="rfs:debootstrapvarianttype_restriction">
-        <attribute name="includepkgs" type="string" use="optional">
-          <annotation>
-            <documentation>
-              A comma-separated list of additional packages at debootstrap runtime.
-            </documentation>
-          </annotation>
-        </attribute>
-      </extension>
-    </simpleContent>
+    <all>
+      <element name="variant" minOccurs="0" maxOccurs="1">
+        <annotation>
+          <documentation>
+            Name  of  the  bootstrap  script  variant to use.
+            The following variants are supported:
+            * minbase: required packages and apt.
+            * buildd: build-essential packages.
+            * fakechroot: installs the packages without root privileges.
+          </documentation>
+        </annotation>
+        <simpleType>
+          <restriction base="string">
+            <enumeration value="minbase" />
+            <enumeration value="buildd" />
+            <enumeration value="fakechroot" />
+          </restriction>
+        </simpleType>
+      </element>
+      <element name="include" type="string" minOccurs="0" maxOccurs="1">
+        <annotation>
+          <documentation>
+            Comma separated list of packages which will be added to download and
+            extract lists.
+          </documentation>
+        </annotation>
+      </element>
+      <element name="exclude" type="string" minOccurs="0" maxOccurs="1">
+        <annotation>
+          <documentation>
+            Comma separated list of packages which will be removed from download
+            and extract lists.
+            WARNING: you can and probably will exclude essential packages, be
+            careful using this option.
+          </documentation>
+        </annotation>
+      </element>
+    </all>
   </complexType>
-
-  <simpleType name="debootstrapvarianttype_restriction">
-    <annotation>
-      <documentation>
-	Restriction type specifying debootstrap variants.
-        Supported debootstrap variants are minbase, buildd and fakechroot.
-	The variant scratchbox is not supported by th used debootstrap.
-      </documentation>
-    </annotation>
-    <restriction base="string">
-      <enumeration value="minbase" />
-      <enumeration value="buildd" />
-      <enumeration value="fakechroot" />
-    </restriction>
-  </simpleType>
 
   <complexType name="ubi_type">
     <annotation>

--- a/tests/pbuilder-amd64.xml
+++ b/tests/pbuilder-amd64.xml
@@ -25,7 +25,9 @@
 		<hostname>amd64-buster</hostname>
 		<domain>elbe-ci</domain>
 		<console>ttyO0,115200</console>
-		<debootstrapvariant>minbase</debootstrapvariant>
+		<debootstrap>
+			<variant>minbase</variant>
+		</debootstrap>
 		<passwd>foo</passwd>
 
 		<!-- generate a pbuilder environment (before image will be built) -->


### PR DESCRIPTION
This set of patches improves the debootstrap configuration.
The currently used configuration has two drawbacks:

1. One can only inlcude additional packages into debootstrap, if a
    variant is used.
2. There is no possibility to exclude packages from debootstrap.

This patch eliminates these drawbacks.

A possible new configuration looks like:

```
<debootstrap>
    <variant>minbase</variant>
    <include>ca-certificates</inlcude>
    <exlucde>systemd-timesyncd</exclude>
</debootstrap>
```

If a project contains an old debootstrapvariant configuration, it will
automatically be replaced during pre-processing.

All examples and tests have been updated to use the new configuration.

Signed-off-by: Daniel Braunwarth <daniel.braunwarth@kuka.com>