### PR TITLE
Add development container for usage with Podman

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,7 @@ contrib/debathena-transform-lighttpd/debian/*.log
 contrib/debathena-transform-lighttpd/debian/debathena-transform-lighttpd/
 contrib/debathena-transform-lighttpd/debian/debhelper-build-stamp
 contrib/debathena-transform-lighttpd/debian/files
+
+# initvm and ELBE builds
+initvm/
+elbe-build-*/

--- a/contrib/container/Containerfile
+++ b/contrib/container/Containerfile
@@ -1,0 +1,32 @@
+# ELBE development container
+# Copyright (c) 2021 Daniel Braunwarth <daniel@braunwarth.dev>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+FROM debian:bullseye-slim
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update --yes && apt-get install --yes --no-install-recommends \
+        systemd \
+        python3 \
+        python3-libvirt \
+        python3-lxml \
+        python3-gpg \
+        python3-mako \
+        python3-suds \
+        python3-debian \
+        wget \
+        bzip2 \
+        make \
+        cpio \
+        rsync \
+        ssh \
+        qemu-system-x86 \
+        qemu-utils \
+        libvirt-daemon-system \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN systemctl enable libvirtd.service
+
+CMD [ "/lib/systemd/systemd" ]

--- a/contrib/container/Makefile
+++ b/contrib/container/Makefile
@@ -1,0 +1,33 @@
+# ELBE development container
+# Copyright (c) 2021 Daniel Braunwarth <daniel@braunwarth.dev>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+build:
+	podman image build --tag elbe-devel .
+
+start:
+	podman container list | grep elbe-devel || \
+	podman container run \
+		--name elbe-devel \
+		--detach \
+		--rm \
+		--volume $(shell git rev-parse --show-toplevel):/usr/src \
+		--workdir /usr/src \
+		--privileged \
+		elbe-devel
+
+stop:
+	podman container stop --ignore elbe-devel
+
+attach: start
+	podman container exec \
+		--tty \
+		--interactive \
+		elbe-devel \
+		/bin/bash
+
+clean: stop
+	podman image rm --force elbe-devel || true
+
+.PHONY: build start stop clean atach

--- a/contrib/container/README.md
+++ b/contrib/container/README.md
@@ -1,0 +1,108 @@
+# ELBE development container
+
+[//]: # "Copyright (c) 2021 Daniel Braunwarth <daniel@braunwarth.dev>"
+[//]: # "SPDX-License-Identifier: GPL-3.0-or-later"
+
+This container is intended to build and run ELBE from Git sources.
+
+To build and run the container [Podman](https://podman.io/) should be used.
+
+The container is based on the official Debian Bullseye image in the slim
+variant.
+
+## Dependencies
+
+To be able to build and use this container you need:
+
+- [Make](https://www.gnu.org/software/make/)
+- [Podman](https://podman.io/)
+
+  See <https://podman.io/getting-started/> for information how to get started
+  with Podman.
+
+## Security
+
+Unfortunately podman cannot be used in rootless mode, because ELBE needs the
+`CAP_SYS_ADMIN` capability to be able to facilitate QEMU.
+
+At the moment the container is started in privileged mode. This should be
+restricted in the future.
+
+## Usage
+
+### Build container image
+
+To build the container image run:
+
+```shell
+sudo make build
+```
+
+The resulting image is named `elbe-devel`.
+
+### Start container
+
+To start the container run:
+
+```shell
+sudo make start
+```
+
+The started container is named `elbe-devel`. It is not possible to start
+multiple container instances.
+
+### Stop container
+
+To stop the container run:
+
+```shell
+sudo make stop
+```
+
+### Attach to running container
+
+To attach to a running container run:
+
+```shell
+sudo make attach
+```
+
+The default working directory is `/usr/src`. This is where the Git repository
+is mounted to.
+
+### Build initvm
+
+To build an initvm attach to the running container and run:
+
+```shell
+./elbe initvm --devel create elbepack/init/initvm-ssh-root-open-danger.xml
+```
+
+To be able to sync the ELBE sources between the Git repository and the initvm
+we must be able to connect to the initvm via SSH as root user. For this reason
+we are using `elbepack/init/initvm-ssh-root-open-danger.xml`.
+
+### Add already existing initvm to container
+
+To add an already existing initvm to a newly created container instance attach
+to the running container and run:
+
+```shell
+virsh --connect qemu:///system define initvm/libvirt.xml
+```
+
+### Update ELBE in initvm
+
+To update the used ELBE sources in an initvm run:
+
+```shell
+./elbe initvm --devel sync
+```
+
+### Clean-up
+
+To remove the container instance and image run:
+
+```shell
+sudo make clean
+```


### PR DESCRIPTION
This patch adds a development container for usage with Podman.

This new container provides a few improvements compared to the already
existing one:

- The new container image is based on the official Debian Bullseye image
  in the slim variant. The existing container is using a three years old
  image based on Debian Stretch.

- The new container image only contains a minimal set of Debian packages
  which are needed to run ELBE from the Git sources.

  The container image has a size of 329 MB.
  The already existing image has a size of 1.15 GB.

- To build and run the container image / instance Podman is used. The
  main reason to switch from Docker to Podman - in this case - is the
  usage of systemd inside the container.

  With Docker it is not that easy to run systemd in a container. This
  can be seen at the already existing container.

  With Podman it is very easy to achieve this.

  See
  https://developers.redhat.com/blog/2019/04/24/how-to-run-systemd-in-a-container
  for detailed information.

Right now there is one downside of the new container: the container
instance is started as rootful container in privileged mode.

Podman's rootless mode cannot be used, because the CAP_SYS_ADMIN
capability is needed which is only granted in rootful mode.

The privileged mode is used right now, because I wasn't able the create
and use an initvm without it. Dumb copying of the security settings
from the existing container was not working unfortunately.

This is something which should be optimized in the future.

Signed-off-by: Daniel Braunwarth <daniel@braunwarth.dev>