### PR TITLE
Add posibility to define squashfs package options

### DIFF
--- a/elbepack/efilesystem.py
+++ b/elbepack/efilesystem.py
@@ -467,8 +467,12 @@ class TargetFs(ChRootFilesystem):
             sfs_name = self.xml.text("target/package/squashfs/name")
             os.chdir(self.fname(''))
             try:
-                do("mksquashfs %s %s/%s -noappend -no-progress" %
-                   (self.fname(''), targetdir, sfs_name))
+                options = ''
+                if self.xml.has("target/package/squashfs/options"):
+                    options = self.xml.text("target/package/squashfs/options")
+
+                do("mksquashfs %s %s/%s -noappend -no-progress %s" %
+                   (self.fname(''), targetdir, sfs_name, options))
                 # only append filename if creating mksquashfs was successful
                 self.images.append(sfs_name)
             except CommandError:

--- a/schema/dbsfed.xsd
+++ b/schema/dbsfed.xsd
@@ -1758,6 +1758,13 @@
           </documentation>
         </annotation>
       </element>
+      <element name="options" type="rfs:string" minOccurs="0">
+        <annotation>
+          <documentation>
+             options passed to the mksquashfs command
+          </documentation>
+        </annotation>
+      </element>
     </all>
     <attribute ref="xml:base"/>
   </complexType>


### PR DESCRIPTION
This patch adds the possibility to define squashfs package options.
The defined options are appended to the mksquashfs command.

This patch fixes #316.

Signed-off-by: Daniel Braunwarth <daniel@braunwarth.dev>