### PR TITLE
Remove testdeb.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 all:
-	./test/testdeb.sh
 	dpkg-buildpackage
 	lintian
 	cd contrib/debathena-transform-lighttpd && \


### PR DESCRIPTION
The testdeb.sh script has been removed by
f6383cb129ba340050df6c52a17826736611b74c
long time ago.

This fixed #308.

Signed-off-by: Daniel Braunwarth <daniel@braunwarth.dev>