### PR TITLE
efilesystem: close elbe_base.xml after use

### DIFF
--- a/elbepack/efilesystem.py
+++ b/elbepack/efilesystem.py
@@ -409,8 +409,8 @@ class TargetFs(ChRootFilesystem):
             else:
                 self.mkdir("etc")
 
-        f = self.open("etc/fstab", "w")
         if xml.tgt.has("fstab"):
+            f = self.open("etc/fstab", "w")
             for fs in xml.tgt.node("fstab"):
                 if not fs.has("nofstab"):
                     fstab = fstabentry(xml, fs)

--- a/elbepack/efilesystem.py
+++ b/elbepack/efilesystem.py
@@ -191,6 +191,7 @@ class ElbeFilesystem(Filesystem):
 
         elbe_base = self.open("etc/elbe_base.xml", "wb")
         xml.xml.write(elbe_base)
+        elbe_base.close()
         self.chmod("etc/elbe_base.xml", stat.S_IREAD)
 
     def write_licenses(self, f, pkglist, xml_fname=None):


### PR DESCRIPTION
this fixes

Exception ignored in: <_io.FileIO name='/home/jenkins/agent/workspace/ebian_traut-rfs_master/image/chroot/etc/elbe_base.xml' mode='wb' closefd=True>
[2022-05-05T15:01:57.115Z] Traceback (most recent call last):
[2022-05-05T15:01:57.115Z]   File "/usr/lib/python3/dist-packages/elbepack/elbeproject.py", line 607, in build
[2022-05-05T15:01:57.115Z]     self.buildenv.rfs.dump_elbeversion(self.xml)
[2022-05-05T15:01:57.115Z] ResourceWarning: unclosed file <_io.BufferedWriter name='/home/jenkins/agent/workspace/ebian_traut-rfs_master/image/chroot/etc/elbe_base.xml'>

Signed-off-by: Manuel Traut <manut@mecka.net>