### PR TITLE
validation.txt: Only cat it if it exists

### DIFF
--- a/elbepack/elbeproject.py
+++ b/elbepack/elbeproject.py
@@ -701,7 +701,8 @@ class ElbeProject:
 
         self.targetfs.pack_images(self.builddir)
 
-        system('cat "%s"' % self.validationpath)
+        if os.path.exists(self.validationpath):
+          system('cat "%s"' % self.validationpath)
 
     def pdebuild_init(self):
         # Remove pdebuilder directory, containing last build results


### PR DESCRIPTION
If running elbe buildchroot standalone with no full-pkglist the
'validation.txt' doesn't exist and therefore returns an error-code.

Signed-off-by: Manuel Traut <manuel.traut@mt.com>