### PR TITLE
Task/improve sdk build

### DIFF
--- a/debian/python3-elbe-buildenv.install
+++ b/debian/python3-elbe-buildenv.install
@@ -1,5 +1,6 @@
 ./usr/lib/python3.*/*-packages/elbepack/commands/adjustpkgs.py
 ./usr/lib/python3.*/*-packages/elbepack/commands/buildchroot.py
+./usr/lib/python3.*/*-packages/elbepack/commands/buildsdk.py
 ./usr/lib/python3.*/*-packages/elbepack/commands/buildsysroot.py
 ./usr/lib/python3.*/*-packages/elbepack/commands/chroot.py
 ./usr/lib/python3.*/*-packages/elbepack/commands/db.py

--- a/elbepack/elbeproject.py
+++ b/elbepack/elbeproject.py
@@ -271,6 +271,11 @@ class ElbeProject:
             ignore_dev_pkgs = [p.et.text for p in self.xml.node(
                 "target/pkg-blacklist/sysroot")]
 
+        sysroot_pkgs = []
+        if self.xml.tgt.has('sdk-pkg-list'):
+            sysroot_pkgs = [p.et.text for p in self.xml.node(
+                "target/sdk-pkg-list")]
+
         with self.sysrootenv:
             try:
                 cache = self.get_rpcaptcache(env=self.sysrootenv)
@@ -280,7 +285,8 @@ class ElbeProject:
 
             try:
                 cache.mark_install_devpkgs(set(ignore_pkgs),
-                                           set(ignore_dev_pkgs))
+                                           set(ignore_dev_pkgs),
+                                           set(sysroot_pkgs))
             except SystemError as e:
                 logging.exception("Mark install devpkgs failed")
             try:

--- a/elbepack/elbeproject.py
+++ b/elbepack/elbeproject.py
@@ -26,7 +26,7 @@ from elbepack.rfs import BuildEnv
 from elbepack.rpcaptcache import get_rpcaptcache
 from elbepack.efilesystem import TargetFs
 from elbepack.efilesystem import extract_target
-from elbepack.filesystem import size_to_int
+from elbepack.filesystem import size_to_int, Filesystem
 
 from elbepack.aptpkgutils import XMLPackage
 
@@ -43,7 +43,7 @@ from elbepack.pbuilder import (pbuilder_write_config, pbuilder_write_repo_hook,
 from elbepack.repomanager import ProjectRepo
 from elbepack.config import cfg
 from elbepack.templates import write_pack_template
-from elbepack.finetuning import do_prj_finetuning
+from elbepack.finetuning import do_prj_finetuning, do_sdk_finetuning
 
 
 validation = logging.getLogger("validation")
@@ -408,6 +408,11 @@ class ElbeProject:
         hostsysrootpath = os.path.join(self.sdkpath, 'sysroots', 'host')
 
         self.build_host_sysroot(host_pkglist, hostsysrootpath)
+
+        do_sdk_finetuning(self.xml,
+                          self.buildenv,
+                          Filesystem(self.sdkpath),
+                          self.builddir)
 
         n = gen_sdk_scripts(triplet,
                             elfcode,

--- a/elbepack/finetuning.py
+++ b/elbepack/finetuning.py
@@ -60,6 +60,9 @@ class FinetuningAction:
     def execute_prj(self, buildenv, target, _builddir):
         self.execute(buildenv, target)
 
+    def execute_sdk(self, buildenv, sdk, _builddir):
+        self.execute(buildenv, sdk)
+
 
 @FinetuningAction.register('image_finetuning', False)
 class ImageFinetuningAction(FinetuningAction):
@@ -72,6 +75,9 @@ class ImageFinetuningAction(FinetuningAction):
                                   "used in <image-finetuning>" % self.tag)
 
     def execute_img(self, _buildenv, _target, _builddir, _loop_dev):
+        raise NotImplementedError('execute_img() not implemented')
+
+    def execute_sdk(self, _buildenv, _sdk, _builddir):
         raise NotImplementedError('execute_img() not implemented')
 
 
@@ -127,6 +133,9 @@ class BuildenvMkdirAction(FinetuningAction):
     def execute(self, buildenv, _target):
         do("mkdir -p %s" % buildenv.rfs.fname(self.node.et.text))
 
+    def execute_sdk(self, _buildenv, _sdk, _builddir):
+        raise NotImplementedError('execute_sdk() not implemented')
+
 
 @FinetuningAction.register('cp')
 class CpAction(FinetuningAction):
@@ -153,6 +162,9 @@ class BuildenvCpAction(FinetuningAction):
         for f in src:
             do(cmd % f)
 
+    def execute_sdk(self, _buildenv, _sdk, _builddir):
+        raise NotImplementedError('execute_sdk() not implemented')
+
 
 @FinetuningAction.register('b2t_cp')
 class B2TCpAction(FinetuningAction):
@@ -166,6 +178,9 @@ class B2TCpAction(FinetuningAction):
         for f in src:
             do(cmd % f)
 
+    def execute_sdk(self, _buildenv, _sdk, _builddir):
+        raise NotImplementedError('execute_sdk() not implemented')
+
 
 @FinetuningAction.register('t2b_cp')
 class T2BCpAction(FinetuningAction):
@@ -178,6 +193,9 @@ class T2BCpAction(FinetuningAction):
         cmd = "cp -av %s {}".format(buildenv.rfs.fname(self.node.et.text))
         for f in src:
             do(cmd % f)
+
+    def execute_sdk(self, _buildenv, _sdk, _builddir):
+        raise NotImplementedError('execute_sdk() not implemented')
 
 
 @FinetuningAction.register('t2p_mv')
@@ -197,6 +215,9 @@ class T2PMvAction(FinetuningAction):
         cmd = "mv -v %s {}".format(dest)
         for f in src:
             do(cmd % f)
+
+    def execute_sdk(self, _buildenv, _sdk, _builddir):
+        raise NotImplementedError('execute_sdk() not implemented')
 
 
 @FinetuningAction.register('mv')
@@ -226,6 +247,15 @@ class LnAction(FinetuningAction):
                    """/bin/sh -c 'ln -sf %s "%s"' """ %
                    (target_name, link_name))
 
+    def execute_sdk(self, _buildenv, _sdk, _builddir):
+        target_name = self.node.et.attrib['path']
+        link_name = self.node.et.text
+        returnpath = os.getcwd()
+        os.chdir(_sdk.path)
+        try:
+            do('ln -sf %s "%s"' % (target_name, link_name))
+        finally:
+            os.chdir(returnpath)
 
 @FinetuningAction.register('buildenv_mv')
 class BuildenvMvAction(FinetuningAction):
@@ -238,6 +268,9 @@ class BuildenvMvAction(FinetuningAction):
         cmd = "mv -v %s {}".format(buildenv.rfs.fname(self.node.et.text))
         for f in src:
             do(cmd % f)
+
+    def execute_sdk(self, _buildenv, _sdk, _builddir):
+        raise NotImplementedError('execute_sdk() not implemented')
 
 
 @FinetuningAction.register('adduser')
@@ -280,6 +313,9 @@ class AddUserAction(FinetuningAction):
                 stdin = "%s\n%s\n" % (att["passwd"], att["passwd"])
                 chroot(target.path, cmd, stdin=stdin)
 
+    def execute_sdk(self, _buildenv, _sdk, _builddir):
+        raise NotImplementedError('execute_sdk() not implemented')
+
 
 @FinetuningAction.register('addgroup')
 class AddGroupAction(FinetuningAction):
@@ -299,6 +335,9 @@ class AddGroupAction(FinetuningAction):
             cmd = '/usr/sbin/groupadd %s "%s"' % (options,
                                                   self.node.et.text)
             chroot(target.path, cmd)
+
+    def execute_sdk(self, _buildenv, _sdk, _builddir):
+        raise NotImplementedError('execute_sdk() not implemented')
 
 
 @FinetuningAction.register('file')
@@ -372,6 +411,9 @@ class RawCmdAction(FinetuningAction):
         with target:
             chroot(target.path, self.node.et.text)
 
+    def execute_sdk(self, _buildenv, _sdk, _builddir):
+        raise NotImplementedError('execute_sdk() not implemented')
+
 
 @FinetuningAction.register('command')
 class CmdAction(ImageFinetuningAction):
@@ -400,6 +442,9 @@ class CmdAction(ImageFinetuningAction):
         with target:
             chroot(target.path, "/bin/sh", stdin=self.node.et.text)
 
+    def execute_sdk(self, _buildenv, _sdk, _builddir):
+        raise NotImplementedError('execute_sdk() not implemented')
+
 
 @FinetuningAction.register('buildenv_command')
 class BuildenvCmdAction(FinetuningAction):
@@ -411,6 +456,9 @@ class BuildenvCmdAction(FinetuningAction):
         with buildenv:
             chroot(buildenv.path, "/bin/sh", stdin=self.node.et.text)
 
+    def execute_sdk(self, _buildenv, _sdk, _builddir):
+        raise NotImplementedError('execute_sdk() not implemented')
+
 
 @FinetuningAction.register('purge')
 class PurgeAction(FinetuningAction):
@@ -421,6 +469,9 @@ class PurgeAction(FinetuningAction):
     def execute(self, _buildenv, target):
         with target:
             chroot(target.path, "dpkg --purge %s" % (self.node.et.text))
+
+    def execute_sdk(self, _buildenv, _sdk, _builddir):
+        raise NotImplementedError('execute_sdk() not implemented')
 
 
 @FinetuningAction.register('updated')
@@ -501,6 +552,9 @@ class UpdatedAction(FinetuningAction):
         # allow downgrades by default
         target.touch_file('/var/cache/elbe/.downgrade_allowed')
 
+    def execute_sdk(self, _buildenv, _sdk, _builddir):
+        raise NotImplementedError('execute_sdk() not implemented')
+
 
 @FinetuningAction.register('artifact')
 class ArtifactAction(FinetuningAction):
@@ -522,6 +576,9 @@ class ArtifactAction(FinetuningAction):
             logging.error("The specified artifact: '%s' doesn't exist",
                            self.node.et.text)
 
+    def execute_sdk(self, _buildenv, _sdk, _builddir):
+        raise NotImplementedError('execute_sdk() not implemented')
+
 
 @FinetuningAction.register('rm_artifact')
 class RmArtifactAction(FinetuningAction):
@@ -539,6 +596,9 @@ class RmArtifactAction(FinetuningAction):
         except ValueError:
             raise FinetuningException("Artifact %s doesn't exist" %
                                       self.node.et.text)
+
+    def execute_sdk(self, _buildenv, _sdk, _builddir):
+        raise NotImplementedError('execute_sdk() not implemented')
 
 
 @FinetuningAction.register('losetup')
@@ -564,6 +624,9 @@ class LosetupAction(FinetuningAction):
         finally:
             cmd = 'losetup --detach "%s"' % loop_dev
             do(cmd)
+
+    def execute_sdk(self, _buildenv, _sdk, _builddir):
+        raise NotImplementedError('execute_sdk() not implemented')
 
 
 @FinetuningAction.register('img_convert')
@@ -602,6 +665,9 @@ class ImgConvertAction(FinetuningAction):
             target.images.remove(src)
             del target.image_packers[src]
 
+    def execute_sdk(self, _buildenv, _sdk, _builddir):
+        raise NotImplementedError('execute_sdk() not implemented')
+
 
 @FinetuningAction.register('set_packer')
 class SetPackerAction(FinetuningAction):
@@ -618,6 +684,9 @@ class SetPackerAction(FinetuningAction):
         packer = self.node.et.attrib['packer']
 
         target.image_packers[img] = packers[packer]
+
+    def execute_sdk(self, _buildenv, _sdk, _builddir):
+        raise NotImplementedError('execute_sdk() not implemented')
 
 
 @FinetuningAction.register('extract_partition')
@@ -640,6 +709,9 @@ class ExtractPartitionAction(ImageFinetuningAction):
 
         target.images.append(self.node.et.text)
         target.image_packers[self.node.et.text] = default_packer
+
+    def execute_sdk(self, _buildenv, _sdk, _builddir):
+        raise NotImplementedError('execute_sdk() not implemented')
 
 
 @FinetuningAction.register('copy_from_partition')
@@ -677,6 +749,9 @@ class CopyFromPartition(ImageFinetuningAction):
 
             target.images.append(aname)
 
+    def execute_sdk(self, _buildenv, _sdk, _builddir):
+        raise NotImplementedError('execute_sdk() not implemented')
+
 
 @FinetuningAction.register('copy_to_partition')
 class CopyToPartition(ImageFinetuningAction):
@@ -700,6 +775,10 @@ class CopyToPartition(ImageFinetuningAction):
             cmd = 'cp -av "%s" "%s"' % (os.path.join(builddir, aname), fname)
             do(cmd)
 
+    def execute_sdk(self, _buildenv, _sdk, _builddir):
+        raise NotImplementedError('execute_sdk() not implemented')
+
+
 @FinetuningAction.register('set_partition_type')
 class SetPartitionTypeAction(ImageFinetuningAction):
 
@@ -718,6 +797,9 @@ class SetPartitionTypeAction(ImageFinetuningAction):
         inp = f't\n{part_nr}\n{part_type}\nw\n'
 
         do(cmd, stdin=inp)
+
+    def execute_sdk(self, _buildenv, _sdk, _builddir):
+        raise NotImplementedError('execute_sdk() not implemented')
 
 
 @FinetuningAction.register("unit-tests")
@@ -744,6 +826,9 @@ class TestSuites(FinetuningAction):
 
         TestSuite.to_file(output, tss)
 
+    def execute_sdk(self, _buildenv, _sdk, _builddir):
+        raise NotImplementedError('execute_sdk() not implemented')
+
 
 @FinetuningAction.register("rm_apt_source")
 class RmAptSource(FinetuningAction):
@@ -760,6 +845,9 @@ class RmAptSource(FinetuningAction):
 
         with open(src_path, "w") as f:
             f.write("\n".join(src_lst))
+
+    def execute_sdk(self, _buildenv, _sdk, _builddir):
+        raise NotImplementedError('execute_sdk() not implemented')
 
 
 def do_finetuning(xml, buildenv, target):
@@ -800,6 +888,29 @@ def do_prj_finetuning(xml, buildenv, target, builddir):
                               "trying to continue anyways")
         except FinetuningException:
             logging.exception("Finetuning Error\n"
+                              "Trying to continue anyways")
+        except Exception as e:
+            logging.exception(str(e))
+            raise
+
+
+def do_sdk_finetuning(xml, buildenv, sdk, builddir):
+
+    if not xml.has('target/sdk-finetuning'):
+        return
+
+    for i in xml.node('target/sdk-finetuning'):
+        try:
+            action = FinetuningAction(i)
+            action.execute_sdk(buildenv, sdk, builddir)
+        except KeyError:
+            logging.exception("Unimplemented sdk-finetuning action '%s'",
+                              i.et.tag)
+        except CommandError:
+            logging.exception("SDKFinetuning Error, "
+                              "trying to continue anyways")
+        except FinetuningException:
+            logging.exception("SDKFinetuning Error\n"
                               "Trying to continue anyways")
         except Exception as e:
             logging.exception(str(e))

--- a/elbepack/makofiles/environment-setup-elbe.mako
+++ b/elbepack/makofiles/environment-setup-elbe.mako
@@ -79,6 +79,7 @@ export OECORE_DISTRO_VERSION="${sdk_version}"
 export OECORE_SDK_VERSION="${sdk_version}"
 export ARCH=x86
 export CROSS_COMPILE=${real_multimach_target_sys}-
+export CMAKE_PREFIX_PATH="$SDKTARGETSYSROOT/usr/lib/${real_multimach_target_sys}/cmake"
 
 # Append environment subscripts
 if [ -d "$OECORE_TARGET_SYSROOT/environment-setup.d" ]; then

--- a/elbepack/rpcaptcache.py
+++ b/elbepack/rpcaptcache.py
@@ -136,7 +136,7 @@ class RPCAPTCache(InChRootObject):
                        auto_inst=not nodeps,
                        from_user=from_user)
 
-    def mark_install_devpkgs(self, ignore_pkgs, ignore_dev_pkgs):
+    def mark_install_devpkgs(self, ignore_pkgs, ignore_dev_pkgs, additional_pkgs):
 
         # we don't want to ignore libc
         ignore_pkgs.discard('libc6')
@@ -197,6 +197,8 @@ class RPCAPTCache(InChRootObject):
             dev_lst.append(pkg)
 
         mark_install(dev_lst, "-dev")
+        for p in additional_pkgs:
+            self.mark_install(p, '')
 
         # ensure that the symlinks package will be installed (it's
         # needed for fixing links inside the sysroot

--- a/schema/dbsfed.xsd
+++ b/schema/dbsfed.xsd
@@ -1098,7 +1098,15 @@
       <element name="hostsdk-pkg-list" type="rfs:pkg-list" minOccurs="0" maxOccurs="1">
         <annotation>
           <documentation>
-	    install the given packages into the hostsdk. (ignores pin and versions,
+	    install the given packages into the host sysroot of the sdk. (ignores pin and versions,
+	    with the current implementation)
+          </documentation>
+        </annotation>
+      </element>
+      <element name="sdk-pkg-list" type="rfs:pkg-list" minOccurs="0" maxOccurs="1">
+        <annotation>
+          <documentation>
+	    install the given packages into target sysroot of the sdk. (ignores pin and versions,
 	    with the current implementation)
           </documentation>
         </annotation>

--- a/schema/dbsfed.xsd
+++ b/schema/dbsfed.xsd
@@ -1074,6 +1074,15 @@
           </documentation>
         </annotation>
       </element>
+      <element name="sdk-finetuning" type="rfs:sdk-finetuning" minOccurs="0">
+        <annotation>
+          <documentation>
+            apply the given commands to the sdk directory, after target and host sysroots have
+            been generated. Currently supported use-cases are:
+              * file operations like, cp, mv, ..
+          </documentation>
+        </annotation>
+      </element>
       <element name="pbuilder" type="rfs:pbuilder" minOccurs="0" maxOccurs="1">
         <annotation>
           <documentation>
@@ -2288,6 +2297,78 @@
         <annotation>
           <documentation>
 	    Allows to generate test suites for the project.
+          </documentation>
+        </annotation>
+      </element>
+    </choice>
+  </group>
+
+  <complexType name="sdk-finetuning">
+    <annotation>
+      <documentation>
+         container for sdk-finetuning commands; these commands are executed in the
+         sdk directory, after the host and target sysroots have been generated.
+      </documentation>
+    </annotation>
+    <sequence>
+      <group ref="rfs:sdk-action" minOccurs="0" maxOccurs="unbounded" />
+    </sequence>
+    <attribute ref="xml:base"/>
+  </complexType>
+
+  <group name="sdk-action">
+    <annotation>
+      <documentation>
+        definition of sdk finetuning commands
+      </documentation>
+    </annotation>
+    <choice>
+      <element name="file" type="rfs:file" minOccurs="0">
+        <annotation>
+          <documentation>
+            write or append text to a file
+          </documentation>
+        </annotation>
+      </element>
+      <element name="rm" type="rfs:rm" minOccurs="0">
+        <annotation>
+          <documentation>
+            remove a file or directory (recursive). Also allows specifying an exclude pattern.
+          </documentation>
+        </annotation>
+      </element>
+      <element name="cp" type="rfs:cpmv" minOccurs="0">
+        <annotation>
+          <documentation>
+            copy a file or directory (recursive)
+          </documentation>
+        </annotation>
+      </element>
+      <element name="ln" type="rfs:cpmv" minOccurs="0">
+        <annotation>
+          <documentation>
+            create a symbolic link
+          </documentation>
+        </annotation>
+      </element>
+      <element name="mv" type="rfs:cpmv" minOccurs="0">
+        <annotation>
+          <documentation>
+            move a file or directory
+          </documentation>
+        </annotation>
+      </element>
+      <element name="mkdir" type="rfs:string" minOccurs="0">
+        <annotation>
+          <documentation>
+            create a directory
+          </documentation>
+        </annotation>
+      </element>
+      <element name="mknod" type="rfs:mknod" minOccurs="0">
+        <annotation>
+          <documentation>
+            move a file or directory
           </documentation>
         </annotation>
       </element>


### PR DESCRIPTION
Improvements for building a cross-sdk:

- Make the subcommand available if installed with debian packages
- Enable specifying addtional packages that shall become part of the target-sysroot
- Add searchpath for cmake files to the cross-sdk environment
- Enable finetuning of the SDK via XML