### PR TITLE
Example usage of parts of ELBE in a cloud-based CI

### DIFF
--- a/contrib/k8s/Dockerfile
+++ b/contrib/k8s/Dockerfile
@@ -1,0 +1,29 @@
+FROM debian:bullseye-slim
+
+USER root
+
+ENV DEBIAN_FRONTEND noninteractive
+
+
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        wget gnupg2
+
+# install current elbe
+RUN echo 'deb http://debian.linutronix.de/elbe buster main' > /etc/apt/sources.list.d/elbe.list && \
+    wget http://debian.linutronix.de/elbe/elbe-repo.pub && \
+    apt-key add elbe-repo.pub && \
+    apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        python3-elbe-buildenv \
+	locales && \
+    apt-get clean -y && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && locale-gen
+
+RUN echo "root:elbe" | chpasswd

--- a/contrib/k8s/README.md
+++ b/contrib/k8s/README.md
@@ -1,0 +1,33 @@
+Use ELBE with Jenkins on a k8s cluster
+======================================
+
+ELBE can be also used on a Jenkins/k8s based CI.
+
+For setting up the infrastructure, see eg
+https://jenkinsci.github.io/kubernetes-operator/
+
+Additionaly these resources are needed on the cluster if
+the binfmt_misc kernel module is not loaded by default in
+the cluster nodes:
+
+vm-modules-pvc.yaml
+vm-modules-pv.yaml
+
+A global shared library named 'elbe' needs to be configured.
+It shall point to the elbe git repo and use the subpath
+'k8s/jenkins-shared-lib'.
+
+https://www.jenkins.io/doc/book/pipeline/shared-libraries/
+
+Dockerfile
+----------
+Image that includes the needed parts of elbe.
+It shall be built and put to the the container registry of the cluster.
+
+jenkins-shared-lib
+------------------
+The shared lib expects, that the Jenkins environment includes
+a variable 'DOCKER_REGISTRY' that points to the base url of the
+used container registry.
+
+

--- a/contrib/k8s/example/Jenkinsfile
+++ b/contrib/k8s/example/Jenkinsfile
@@ -1,0 +1,3 @@
+@Library('elbe') _
+
+elbebuild("example-rfs.xml", true)

--- a/contrib/k8s/jenkins-shared-lib/vars/elbebuild.groovy
+++ b/contrib/k8s/jenkins-shared-lib/vars/elbebuild.groovy
@@ -1,0 +1,54 @@
+def call(String elbexml, Boolean buildsdk)
+{
+  def podlabel = "elbe-${elbexml}-${UUID.randomUUID().toString()}"
+
+  properties([disableResume()])
+
+  podTemplate(label       : "${podlabel}",
+              podRetention: onFailure(),
+              containers  : [containerTemplate(name                 : 'elbe',
+                                               image                : "${env.DOCKER_REGISTRY}/elbeimage:latest",
+                                               alwaysPullImage      : true,
+                                               resourceRequestCpu   : '2000m',
+                                               resourceRequestMemory: '16Gi',
+                                               resourceLimitCpu     : '2000m',
+                                               resourceLimitMemory  : '16Gi',
+                                               ttyEnabled           : true,
+                                               privileged           : true,
+                                               command              : 'cat'),
+                            ],
+              envVars     : [containerEnvVar(key  : 'HOME',
+                                             value: '/home/jenkins/agent'),
+                            ],
+              volumes     : [persistentVolumeClaim(claimName        : 'vm-modules-pvc',
+                                                   mountPath        : '/lib/modules'),
+                            ],
+             )
+  {
+    node ("${podlabel}") {
+      stage('checkout') {
+        def gitscm = checkout scm
+        env.GIT_BRANCH = gitscm.GIT_BRANCH
+      }
+      container('elbe') {
+        stage('load kernel modules') {
+          sh "modprobe binfmt_misc"
+          sh "update-binfmts --enable qemu-arm"
+        }
+        stage('elbe image build') {
+          sh "test -d archive && elbe chg_archive ${elbexml} archive || /bin/true"
+          sh "elbe buildchroot -t image ${elbexml}"
+        }
+        stage('elbe SDK build') {
+          if (buildsdk) {
+            sh "elbe buildsdk image"
+          }
+        }
+        stage('store artifacts') {
+          sh "rm -rf image/chroot image/target image/repo image/sysroot"
+          archiveArtifacts artifacts: "image/*"
+        }
+      }
+    }
+  }
+}

--- a/contrib/k8s/vm-modules-pv.yaml
+++ b/contrib/k8s/vm-modules-pv.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: vm-modules-pv
+  labels:
+    type: local
+spec:
+  storageClassName: manual
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteMany
+  hostPath:
+    path: "/lib/modules"

--- a/contrib/k8s/vm-modules-pvc.yaml
+++ b/contrib/k8s/vm-modules-pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: vm-modules-pvc
+spec:
+  storageClassName: manual
+  volumeName: vm-modules-pv
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 10Gi


### PR DESCRIPTION
This shows how elbe can be used in a Jenkins based CI
hosted on a kubernetes cluster.

Signed-off-by: Manuel Traut <manuel.traut@mt.com>