### PR TITLE
packers: Add support for deb packages

### DIFF
--- a/elbepack/efilesystem.py
+++ b/elbepack/efilesystem.py
@@ -19,7 +19,7 @@ from elbepack.version import elbe_version
 from elbepack.hdimg import do_hdimg
 from elbepack.fstab import fstabentry
 from elbepack.licencexml import copyright_xml
-from elbepack.packers import default_packer
+from elbepack.packers import default_packer, packers, DebPacker
 from elbepack.shellhelper import (system,
                                   CommandError,
                                   do,
@@ -401,6 +401,7 @@ class TargetFs(ChRootFilesystem):
         self.xml = xml
         self.images = []
         self.image_packers = {}
+        packers['deb'] = DebPacker(xml.defs['arch'], xml.text('/project/version'))
 
     def write_fstab(self, xml):
         if not self.exists("etc"):

--- a/elbepack/packers.py
+++ b/elbepack/packers.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import os
+from elbepack.debpkg import build_binary_deb
 from elbepack.shellhelper import CommandError, do
 
 class Packer:
@@ -64,6 +65,27 @@ class TarArchiver(Packer):
             return None
 
         return fname + self.suffix
+
+
+class DebPacker(Packer):
+    def __init__(self, arch, version):
+        self.arch = arch
+        self.version = version
+
+    def pack_file(self, builddir, fname):
+        pkgname = fname
+        try:
+            pkgname = fname.split('.')[0]
+        except:
+            pass
+
+        return build_binary_deb(pkgname,
+                                self.arch,
+                                self.version,
+                                'description of %s' % pkgname,
+                                [(os.path.join(builddir, fname), '.')],
+                                '',
+                                builddir)
 
 
 packers = {'none': NoPacker(),

--- a/schema/dbsfed.xsd
+++ b/schema/dbsfed.xsd
@@ -2486,6 +2486,7 @@
       <enumeration value="tarxz" />
       <enumeration value="targz" />
       <enumeration value="tarzstd" />
+      <enumeration value="deb" />
     </restriction>
   </simpleType>
 


### PR DESCRIPTION
For example initrd images might be used as input as build-dependency
of a kernel package. Therefore implement a packer that is able to
build simple debian packages.

Signed-off-by: Manuel Traut <manuel.traut@mt.com>