### PR TITLE
Restart ELBE daemon service on failure

### DIFF
--- a/debian/python3-elbe-daemon.service
+++ b/debian/python3-elbe-daemon.service
@@ -6,6 +6,7 @@ Documentation=man:elbe-daemon(1)
 Type=simple
 EnvironmentFile=/etc/default/python3-elbe-daemon
 ExecStart=/usr/bin/elbe $DAEMON_ARGS
+Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The ELBE daemon service might crash due to internal errors or resource shortages. At the moment the service does not recover from this state. The change makes the service restart when its execution failed. This is especially helpful when running the ELBE initvm in automated environments such as CI/CD infrastructures.