### PR TITLE
README.adoc: add the missing libvirt-clients package

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -13,7 +13,7 @@ Software Dependencies
 ---------------------
 If using ELBE from git repository directly, you'll need following packages installed:
 
-    apt install python3 python3-debian python3-mako python3-lxml python3-apt python3-gpg python3-suds python3-libvirt qemu-utils qemu-kvm p7zip-full make python3-passlib
+    apt install python3 python3-debian python3-mako python3-lxml python3-apt python3-gpg python3-suds python3-libvirt qemu-utils qemu-kvm p7zip-full make python3-passlib libvirt-clients
 
 
 Crash Course


### PR DESCRIPTION
This package installs virsh binary.