### PR TITLE
Support primary_key in mirror tag

### DIFF
--- a/elbepack/commands/init.py
+++ b/elbepack/commands/init.py
@@ -211,8 +211,10 @@ def run_command(argv):
         shutil.copyfile(args[0],
                         os.path.join(out_path, "source.xml"))
 
-
         keys = []
+        if xml.has('initvm/mirror/primary_key'):
+            key = xml.node('initvm/mirror/primary_key')
+            keys.append(key.et.text)
         for key in xml.all(".//initvm/mirror/url-list/url/raw-key"):
             keys.append(key.et.text)
 

--- a/elbepack/elbexml.py
+++ b/elbepack/elbexml.py
@@ -142,6 +142,21 @@ class ElbeXML:
 
         return replace_localmachine(mirror, initvm)
 
+    def get_primary_key(self, cdrompath, hostsysroot=False):
+        key = ''
+
+        if self.prj.has("mirror/cdrom") and cdrompath:
+            pass
+        elif self.prj.has("mirror/primary_host"):
+            m = self.prj.node("mirror")
+
+            if hostsysroot and self.prj.has("mirror/host") and self.prj.has("mirror/host_key"):
+                key = m.text("host_key")
+            elif self.prj.has("mirror/primary_key"):
+                key = m.text("primary_key")
+
+        return key
+
     # XXX: maybe add cdrom path param ?
     def create_apt_sources_list(self, build_sources=False, initvm=True, hostsysroot=False):
 

--- a/elbepack/rfs.py
+++ b/elbepack/rfs.py
@@ -274,8 +274,11 @@ class BuildEnv:
         Adds the binary OpenPGP keyring 'key' as a trusted apt keyring
         with file name 'keyname'.
         """
-        with open(self.rfs.fname(f"/etc/apt/trusted.gpg.d/{keyname}"), "wb") as outfile:
+        keyfile = self.rfs.fname(f"/etc/apt/trusted.gpg.d/{keyname}")
+        with open(keyfile, "wb") as outfile:
             outfile.write(key)
+
+        return keyfile
 
     def import_keys(self):
         if self.xml.has('project/mirror/url-list'):

--- a/elbepack/virtapt.py
+++ b/elbepack/virtapt.py
@@ -150,6 +150,11 @@ class VirtApt:
             outfile.write(key)
 
     def import_keys(self):
+        if self.xml.has('project/mirror/primary_host') and self.xml.has('project/mirror/primary_key'):
+            m = self.xml.node('project/mirror')
+            key = "\n".join(line.strip(" \t") for line in m.text('primary_key').splitlines()[1:-1])
+            self.add_key(unarmor_openpgp_keyring(key), "elbe-virtapt-primary-key.gpg")
+
         if self.xml.has('project/mirror/url-list'):
             # Should we use self.xml.prj.has("noauth")???
             #

--- a/schema/dbsfed.xsd
+++ b/schema/dbsfed.xsd
@@ -283,6 +283,13 @@ SPDX-FileCopyrightText: Linutronix GmbH
           </documentation>
         </annotation>
       </element>
+      <element name="primary_key" type="rfs:string" minOccurs="0" maxOccurs="1">
+        <annotation>
+          <documentation>
+	    Raw public key used to sign the primary mirror
+          </documentation>
+        </annotation>
+      </element>
       <element name="primary_proxy" type="rfs:string" minOccurs="0" maxOccurs="1">
         <annotation>
           <documentation>

--- a/schema/dbsfed.xsd
+++ b/schema/dbsfed.xsd
@@ -312,6 +312,13 @@ SPDX-FileCopyrightText: Linutronix GmbH
           </documentation>
         </annotation>
       </element>
+      <element name="host_key" type="rfs:string" minOccurs="0" maxOccurs="1">
+        <annotation>
+          <documentation>
+	    Raw public key used to sign the host mirror
+          </documentation>
+        </annotation>
+      </element>
       <element name="url-list" type="rfs:url-list" minOccurs="0">
         <annotation>
           <documentation>


### PR DESCRIPTION
This adds support for a public key of the primary mirror. The primary key is used in the following places:
- to verify the Release of the primary mirror for the initvm
- to add the primary key to the keyring of the initvm
- to call debootstrap with the primary key when building the rootfs
- to call debootstrap with the primary key when creating a pbuilder

Resolves #104 and #365.