### PR TITLE
Take GPG keys from /usr/share/keyrings/

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -15,7 +15,7 @@ If using ELBE from git repository directly, you'll need following packages insta
 
     apt install python3 python3-debian python3-mako python3-lxml python3-apt \
         python3-gpg python3-suds python3-libvirt qemu-utils qemu-kvm p7zip-full \
-        make python3-passlib libvirt-clients libvirt-daemon-system
+        make python3-passlib libvirt-clients libvirt-daemon-system debian-archive-keyring
 
 
 Crash Course

--- a/elbepack/debinstaller.py
+++ b/elbepack/debinstaller.py
@@ -18,6 +18,8 @@ from elbepack.egpg import OverallStatus, check_signature
 from elbepack.shellhelper import CommandError, system
 from elbepack.hashes import HashValidator, HashValidationFailed
 
+GPG_KEYS_LOCATION = "/usr/share/keyrings/"
+
 
 class InvalidSignature(Exception):
     pass
@@ -76,8 +78,8 @@ class SHA256SUMSFile(HashValidator):
 
 def setup_apt_keyring(gpg_home, keyring_fname):
     ring_path = os.path.join(gpg_home, keyring_fname)
-    if not os.path.isdir("/etc/apt/trusted.gpg.d"):
-        print("/etc/apt/trusted.gpg.d doesn't exist")
+    if not os.path.isdir(GPG_KEYS_LOCATION):
+        print(f"{GPG_KEYS_LOCATION} doesn't exist")
         print("apt-get install debian-archive-keyring may "
               "fix this problem")
         sys.exit(20)
@@ -90,13 +92,13 @@ def setup_apt_keyring(gpg_home, keyring_fname):
                   '--batch ' \
                   f'--homedir "{gpg_home}"'
 
-    trustkeys = os.listdir("/etc/apt/trusted.gpg.d")
+    trustkeys = os.listdir(GPG_KEYS_LOCATION)
     for key in trustkeys:
         print(f"Import {key}: ")
         try:
             system(
                 f'gpg {gpg_options} '
-                f'--import "{os.path.join("/etc/apt/trusted.gpg.d", key)}"')
+                f'--import "{os.path.join(GPG_KEYS_LOCATION, key)}"')
         except CommandError:
             print(f'adding keyring "{key}" to keyring "{ring_path}" failed')
 


### PR DESCRIPTION
In both Debian and Ubuntu, Debian archive keys are provided by the `debian-archive-keyring` package. The difference is, Debian's variant installs the keys in both `/usr/share/keyrings/` and `/etc/apt/trusted.gpg.d`. But the Ubuntu one installs the keys only to `/usr/share/keyrings/`.

The background is, the keys in `/etc/apt/trusted.gpg.d` are trusted unconditionally by apt. As a result, any package coming from both an official and unofficial distro repository will be trusted by apt as long as it is signed by one of the keys in
`/etc/apt/trusted.gpg.d`. For more information, please, see this answer: https://askubuntu.com/a/1307181/199784.

This background explains why Ubuntu's package doesn't install Debian archive keys into `/etc/apt/trusted.gpg.d` folder.

Hence, as both packages install the keys into `/usr/share/keyrings/`, use this location for both Linux distributions. This approach won't compromise the security in Ubuntu as the user doesn't have to copy the keys from `/usr/share/keyrings/` to `/etc/apt/trusted.gpg.d`.