### PR TITLE
initvm: add an option for additional Debian archive key location

### DIFF
--- a/elbepack/commands/init.py
+++ b/elbepack/commands/init.py
@@ -86,6 +86,12 @@ def run_command(argv):
         default=True,
         help="Skip building Source CDROM")
 
+    oparser.add_option(
+        "--keys_dir",
+        dest="keys_dir",
+        default=None,
+        help="directory, where to find the debian archive keys")
+
     (opt, args) = oparser.parse_args(argv)
 
     if not args:
@@ -172,7 +178,7 @@ def run_command(argv):
             os.putenv("no_proxy", "localhost,127.0.0.1")
 
         try:
-            copy_kinitrd(xml.node("/initvm"), out_path)
+            copy_kinitrd(xml.node("/initvm"), out_path, opt.keys_dir)
         except NoKinitrdException as e:
             msg = str(e)
             logging.error("Failure to download kernel/initrd debian Package:")

--- a/elbepack/commands/initvm.py
+++ b/elbepack/commands/initvm.py
@@ -71,6 +71,12 @@ def run_command(argv):
         default=False,
         help="Also make 'initvm submit' build an SDK.")
 
+    oparser.add_option(
+        "--keys_dir",
+        dest="keys_dir",
+        default=None,
+        help="directory, where to find the debian archive keys")
+
     PreprocessWrapper.add_options(oparser)
 
     (opt, args) = oparser.parse_args(argv)

--- a/elbepack/initvmaction.py
+++ b/elbepack/initvmaction.py
@@ -591,6 +591,9 @@ class CreateAction(InitVMAction):
             if not opt.build_sources:
                 init_opts += ' --skip-build-source'
 
+            if opt.keys_dir:
+                init_opts += f' --keys_dir "{opt.keys_dir}"'
+
             with PreprocessWrapper(xmlfile, opt) as ppw:
                 if cdrom:
                     system(


### PR DESCRIPTION
The option `keys_dir` provides a path to the additional key location.

The use case is when you create an initvm on, for example, Ubuntu where the `debian-archive-keyring` package installs the keys to `/usr/share/keyrings/`. As elbe looks in `/etc/apt/trusted.gpg.d` for the keys, it ignores the ones in `/usr/share/keyrings/`.

Fixes #368 