### PR TITLE
SDK improvements

### DIFF
--- a/elbepack/makofiles/toolchain-shar-extract.sh.mako
+++ b/elbepack/makofiles/toolchain-shar-extract.sh.mako
@@ -310,6 +310,10 @@ ascii_so_files=$($SUDO_EXEC find $native_sysroot -type f -name "*.so" \
 	-exec sh -c "file {} | grep -P ': ASCII text' > /dev/null" \; \
         -printf "'%h/%f' ")
 
+abs_symbolic_links=$($SUDO_EXEC find $native_sysroot -type l \
+    -exec sh -c "file \"{}\" | grep -P 'symbolic link to [\`]?/' > /dev/null" \; \
+    -printf "'%h/%f' ")
+
 if [ "x$native_executable_files" = "x" ]; then
    echo "SDK relocate failed, could not get executalbe files"
    exit 1
@@ -330,6 +334,12 @@ if [ x\$PATCHELF = "x"  ]; then
         echo "use 'sudo dnf install patchelf' on Red Hat Enterprise Linux"
         exit 1
 fi
+
+for link in $abs_symbolic_links; do
+        target=$native_sysroot\`readlink \$link\`
+        rm -f \$link
+        ln -s \$target \$link
+done
 
 for exe in $native_executable_files; do
         if [ \`readlink -f \$exe\` == \`readlink -f $dl_path\` ]; then

--- a/elbepack/makofiles/toolchain-shar-extract.sh.mako
+++ b/elbepack/makofiles/toolchain-shar-extract.sh.mako
@@ -251,6 +251,7 @@ FILECMD=$(which "file")
 if [ x\$FILECMD = "x"  ]; then
         echo "file command not found."
         echo "use 'sudo apt install file' on Debian"
+        echo "use 'sudo dnf install file' on Red Hat Enterprise Linux"
         exit 1
 fi
 
@@ -326,6 +327,7 @@ PATCHELF=\`which patchelf 2>/dev/null\`
 if [ x\$PATCHELF = "x"  ]; then
         echo "SDK could not be relocated. No patchelf found."
         echo "use 'sudo apt install patchelf' on Debian"
+        echo "use 'sudo dnf install patchelf' on Red Hat Enterprise Linux"
         exit 1
 fi
 

--- a/elbepack/makofiles/toolchain-shar-extract.sh.mako
+++ b/elbepack/makofiles/toolchain-shar-extract.sh.mako
@@ -375,7 +375,7 @@ for exe in $target_elf_files; do
 done
 
 for exe in $ascii_so_files; do
-	sed -i "s%/usr/%$native_sysroot/usr/%g" \$exe
+	sed -i -e "s%\([ (]\)/\(usr\|lib\|lib64\)/%\1$native_sysroot/\2/%g" \$exe
 done
 EOF
 


### PR DESCRIPTION
This patch series fixes absolute sysroot paths to point to sysroot files and not to files in the host system. This was happening with symbolic links and with linker script files.