### PR TITLE
initvm: fix python indentation error

### DIFF
--- a/elbepack/commands/fetch_initvm_pkgs.py
+++ b/elbepack/commands/fetch_initvm_pkgs.py
@@ -156,27 +156,27 @@ def run_command(argv):
                 pkg_id = f"{pkg.name}-{pkg.installed_version}"
                 retry = 1
                 while retry < 3:
-                      try:
-                          p = cache[pkg.name]
-                          pkgver = p.installed
-                          dsc = pkgver.fetch_source(opt.srcarchive,
-                                              ElbeAcquireProgress(cb=None),
-                                              unpack=False)
-                          repo.include_init_dsc(dsc, 'initvm')
-                          break
-                      except ValueError:
-                          logging.exception('No package "%s"', pkg_id)
-                          retry = 3
-                      except FetchError:
-                          logging.exception('Package "%s-%s" could not be downloaded', pkg.name, pkgver.version)
-                          retry += 1
-                      except TypeError:
-                          logging.exception('Package "%s" missing name or version', pkg_id)
-                          retry = 3
-                      except CommandError:
-                          logging.exception('Package "%s-%s" could not be added to repo.',
-                                          pkg.name, pkgver.version)
-                    retry += 1
+                    try:
+                        p = cache[pkg.name]
+                        pkgver = p.installed
+                        dsc = pkgver.fetch_source(opt.srcarchive,
+                                            ElbeAcquireProgress(cb=None),
+                                            unpack=False)
+                        repo.include_init_dsc(dsc, 'initvm')
+                        break
+                    except ValueError:
+                        logging.exception('No package "%s"', pkg_id)
+                        retry = 3
+                    except FetchError:
+                        logging.exception('Package "%s-%s" could not be downloaded', pkg.name, pkgver.version)
+                        retry += 1
+                    except TypeError:
+                        logging.exception('Package "%s" missing name or version', pkg_id)
+                        retry = 3
+                    except CommandError:
+                        logging.exception('Package "%s-%s" could not be added to repo.',
+                                        pkg.name, pkgver.version)
+                        retry += 1
                 if retry >= 3:
                     logging.error('Failed to get source Package "%s"', pkg_id)
 


### PR DESCRIPTION
The indentation should be correct. However, double-check the correctness of the patch since it is not immediately obvious where the bottom `retry += 1`  should stay. I think it should be like at like 136.

Unfortunately, I do not have at hand a powerful machine to make a full test. I might be able to do a full test later during the incoming week.