### PR TITLE
elbexml: handle socket timeout for InRelease

### DIFF
--- a/elbepack/elbexml.py
+++ b/elbepack/elbexml.py
@@ -5,6 +5,7 @@
 
 import os
 import re
+import socket
 
 from urllib.error import URLError
 from urllib.request import (urlopen, install_opener, build_opener,
@@ -209,12 +210,16 @@ class ElbeXML:
     def validate_repo(r):
         # pylint: disable=too-many-statements
         try:
-            fp = urlopen(r["url"] + "InRelease", None, 10)
+            fp = urlopen(r["url"] + "InRelease", None, 30)
         except URLError:
             try:
-                fp = urlopen(r["url"] + "Release", None, 10)
+                fp = urlopen(r["url"] + "Release", None, 30)
             except URLError:
                 return False
+            except socket.timeout:
+                return False
+        except socket.timeout:
+            return False
 
         ret = False
         if "srcstr" in r:


### PR DESCRIPTION
I'm having trouble with a custom mirror on AWS, which is resulting in a socket.timeout exception in elbe 50% of the time when downloading the InRelease file. This PR increases the timeout and handles the timeout exception, so that the validation error message shows the URL at fault.

Arguably, something is wrong with the mirror, but I've been unable to fix it, so I'm opting for more tolerant network handling.