### PR TITLE
* Fix the orphaned loop dev created by kpartx -u

### DIFF
--- a/elbepack/hdimg.py
+++ b/elbepack/hdimg.py
@@ -137,10 +137,11 @@ class grubinstaller_base:
 
     @staticmethod
     def losetup(f):
-        loopdev = get_command_out(f'losetup --find --show "{f}"')
+        loopdev = get_command_out(f'losetup --find --show "{f}"').decode().rstrip('\n')
         # old, removed loop devices' kernel structures might be reused, so update the mapping
-        do(f'kpartx -u "{f}"')
-        return loopdev.decode().rstrip('\n')
+        # run kpartx -u on the loop device just created. Running it on the file image will create a second orphaned loop dev
+        do(f'kpartx -u "{loopdev}"')
+        return loopdev
 
 
 class grubinstaller202(grubinstaller_base):


### PR DESCRIPTION
Since updating to 14.9.3 from 14.9.0, we've had issues with an orphaned loop device (and a number of superfluous drive mounts) being left behind after each OS build. This issue only occurred when a project installed grub on a hardrive. I.e. `<grub-install />`

We've tracked the issue down to the `losetup` method in the `grubinstaller_base`  class:

* The method creates a loop device attached to the disk image
* It then calls `kpartx -u` against the same disk image. This results in a second loop device being created, that is not tracked or cleaned up at all

Instead, calling `kpartx -u` against the loop device already attached to file image fixes this issue.
