### PR TITLE
preferences: flexible pkg pinning options

### DIFF
--- a/elbepack/makofiles/preferences.mako
+++ b/elbepack/makofiles/preferences.mako
@@ -6,11 +6,48 @@
 <%!
     import textwrap
     from textwrap import dedent
+
+    def pkg_properties_specified(attrib):
+        """Check if any package pinning properties are provided."""
+        for key in ['version',
+                    'origin',
+                    'release-archive',
+                    'release-component',
+                    'release-label',
+                    'release-name',
+                    'release-origin',
+                    'release-version']:
+            if key in attrib:
+                return True
+        return False
+
+    def generate_pin_text(attrib):
+        """Generate the package pinning properties based on the provided attributes."""
+        # return early as the attributes are mutually exclusive
+        if 'version' in attrib:
+            return f'Pin: version {attrib["version"]}'
+
+        if 'origin' in attrib:
+            return f'Pin: origin {attrib["origin"]}'
+
+        opts = {
+            'a': attrib.get('release-archive'),
+            'c': attrib.get('release-component'),
+            'l': attrib.get('release-label'),
+            'n': attrib.get('release-name'),
+            'o': attrib.get('release-origin'),
+            'v': attrib.get('release-version'),
+        }
+        release_opts = ', '.join([f'{k}={v}' for k, v in opts.items() if v is not None])
+        if release_opts:
+            return f'Pin: release {release_opts}'
+
+        raise RuntimeError('Unknown pinning properties provided')
 %>
-% if prj.has("preference"):
+% if prj.has('preference'):
 Package: *
-Pin: release o=${prj.text("preference")}
-Pin-Priority: ${prj.node("preference").et.attrib["pin"]}
+Pin: release o=${prj.text('preference')}
+Pin-Priority: ${prj.node('preference').et.attrib['pin']}
 
 % endif
 % for pref in prj.et.iter('raw-preference'):
@@ -25,15 +62,9 @@ Pin-Priority: ${porg['pin']}
 % endfor
 % if pkgs:
 %  for n in pkgs:
-%   if "pin" in n.et.attrib.keys():
+%   if pkg_properties_specified(n.et.attrib):
 Package: ${n.et.text}
-Pin: release n=${n.et.attrib["pin"]}
-Pin-Priority: 991
-
-%   endif
-%   if "version" in n.et.attrib.keys():
-Package: ${n.et.text}
-Pin: version ${n.et.attrib["version"]}
+${generate_pin_text(n.et.attrib)}
 Pin-Priority: 1001
 
 %   endif

--- a/elbepack/schema/dbsfed.xsd
+++ b/elbepack/schema/dbsfed.xsd
@@ -2877,10 +2877,61 @@ SPDX-FileCopyrightText: Linutronix GmbH
     </annotation>
     <simpleContent>
       <extension base="rfs:string">
+        <attribute name="origin" type="string" use="optional">
+          <annotation>
+            <documentation>
+              prefer the defined version of the debian package
+            </documentation>
+          </annotation>
+        </attribute>
+        <attribute name="release-name" type="string" use="optional">
+          <annotation>
+            <documentation>
+              prefer the defined codename of the debian package
+            </documentation>
+          </annotation>
+        </attribute>
+        <attribute name="release-archive" type="string" use="optional">
+          <annotation>
+            <documentation>
+              prefer the defined archive/suite of the debian package
+            </documentation>
+          </annotation>
+        </attribute>
+        <attribute name="release-version" type="string" use="optional">
+          <annotation>
+            <documentation>
+              prefer the defined Debian release version of the debian package
+            </documentation>
+          </annotation>
+        </attribute>
+        <attribute name="release-component" type="string" use="optional">
+          <annotation>
+            <documentation>
+              prefer the defined component of the debian package
+            </documentation>
+          </annotation>
+        </attribute>
+        <attribute name="release-origin" type="string" use="optional">
+          <annotation>
+            <documentation>
+              prefer the defined originator of the debian package
+            </documentation>
+          </annotation>
+        </attribute>
+        <attribute name="release-label" type="string" use="optional">
+          <annotation>
+            <documentation>
+              prefer the defined label of the debian package
+            </documentation>
+          </annotation>
+        </attribute>
         <attribute name="pin" type="string" use="optional">
           <annotation>
             <documentation>
               prefer the defined version of the debian package
+
+              Deprecated, use attribute "release-name" instead.
             </documentation>
           </annotation>
         </attribute>
@@ -2979,15 +3030,6 @@ SPDX-FileCopyrightText: Linutronix GmbH
             the given mirrors into the target rootfilesystem.
           </documentation>
         </annotation>
-        <unique name="pkg-list-mutual-exclusive-pkg-pin-or-version">
-          <annotation>
-            <documentation>
-              Only one of pin= or version= can be specified at the same time.
-            </documentation>
-          </annotation>
-          <selector xpath="."/>
-          <field xpath="@pin | @version"/>
-        </unique>
       </element>
     </sequence>
     <attributeGroup ref="xml:specialAttrs"/>
@@ -3024,15 +3066,6 @@ SPDX-FileCopyrightText: Linutronix GmbH
             Reference to a binary debian package which is supposed to be installed.
           </documentation>
         </annotation>
-        <unique name="fullpkg-list-mutual-exclusive-pkg-pin-or-version">
-          <annotation>
-            <documentation>
-              Only one of pin= or version= can be specified at the same time.
-            </documentation>
-          </annotation>
-          <selector xpath="."/>
-          <field xpath="@pin | @version"/>
-        </unique>
       </element>
     </sequence>
     <attributeGroup ref="xml:specialAttrs"/>

--- a/elbepack/xmlpreprocess.py
+++ b/elbepack/xmlpreprocess.py
@@ -143,6 +143,41 @@ def preprocess_initvm_ports(xml):
             forward.getparent().remove(forward)
 
 
+def preprocess_pkg_pinning(xml):
+    """Do search and replace on pkg attributes, replacing 'pin' with 'release-name'."""
+
+    errors = False
+    for pkg in xml.iterfind('//target/pkg-list/pkg'):
+        if 'pin' in pkg.attrib:
+            if 'release-name' in pkg.attrib:
+                logging.error(
+                    'Found attributes "pin" and "release-name" for "%s". '
+                    'Please remove attribute "pin".',
+                    pkg.text)
+                errors = True
+                continue
+
+            logging.warning(
+                'Attribute pin= for element <pkg> is deprecated. Use release-name= instead.')
+
+            pkg.attrib['release-name'] = pkg.attrib['pin']
+            del pkg.attrib['pin']
+
+        # Check that max one attribute of 'version', 'origin', 'release-*' is set
+        if ('version' in pkg.attrib) \
+            + ('origin' in pkg.attrib) \
+            + (0 != len([a for a in pkg.attrib if a.startswith('release-')])) \
+                > 1:
+            logging.error(
+                'Invalid pkg pinning attribute combination for "%s".'
+                ' Use only either of "version" OR "origin" OR "release-* | pin"',
+                pkg.text)
+            errors = True
+
+    if errors:
+        raise XMLPreprocessError("Invalid package pinning attributes")
+
+
 def preprocess_proxy_add(xml, opt_proxy=None):
     """Add proxy to mirrors from CLI arguments or environment variable"""
 
@@ -392,6 +427,8 @@ def xmlpreprocess(xml_input_file, xml_output_file, variants=None, proxy=None, gz
         preprocess_mirrors(xml)
 
         preprocess_passwd(xml)
+
+        preprocess_pkg_pinning(xml)
 
         if schema.validate(xml):
             # if validation succedes write xml file


### PR DESCRIPTION
This enables the use of apt package pinning options other than the codename. For backwards compatibility, the default option used is still the codename (n=).

Signed-off-by: Franz Heger <franz.heger@kuka.com>
Reviewed-by: Daniel Braunwarth <daniel.braunwarth@kuka.com>