### PR TITLE
README: add note about initvm create --devel

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -46,3 +46,7 @@ Crash Course
         elbe-build-<TIMESTAMP>
 
 3. copy the rfs to a sdcard: `sudo dd if=elbe-build*/sdcard.img of=/dev/mmcblk0`
+
+NOTE: When using a specific ELBE git checkout or during development you may
+want to use the `./elbe initvm create --devel` parameter to make the elbe
+version in the initvm match the one in your git checkout.

--- a/README.adoc
+++ b/README.adoc
@@ -37,7 +37,7 @@ Crash Course
 1. use an Elbe XML file (e.g. from /usr/share/doc/elbe/examples or
    examples/ in the elbe source tree)
 
-2. run "./elbe initvm create ./examples/armhf-ti-beaglebone-black.xml
+2. run `./elbe initvm create ./examples/armhf-ti-beaglebone-black.xml`
 
    * This command creates an initvm directory in the current working directory,
    * installs and starts a virtual build environment
@@ -45,4 +45,4 @@ Crash Course
    * after the build finished the build results will be copied into
         elbe-build-<TIMESTAMP>
 
-3. copy the rfs to a sdcard: 'sudo dd if=elbe-build*/sdcard.img of=/dev/mmcblk0'
+3. copy the rfs to a sdcard: `sudo dd if=elbe-build*/sdcard.img of=/dev/mmcblk0`


### PR DESCRIPTION
It is not immediately obvious (to a new user) that the ELBE version inside of the virtual machine differs from the one running on the host, because the version inside the VM is by default installed from `debian.linutronix.de`, while the one on the host may come e.g. from a more recent git checkout.

This can result in a whole slew of issues, either due to the ELBE version inside the virtual machine being incompatible with the one outside of it or because one is trying to fix an issue but the changes do not show any effect.

Add a hint about `--devel` to the README, where users using a git checkout may find it first.

Also use single backticks to make commands in the README appear as Monospace.