### PR TITLE
elbepack: xmlpreprocess: add hostsdk-pkg-list and url-list to mergepaths list

### DIFF
--- a/elbepack/xmlpreprocess.py
+++ b/elbepack/xmlpreprocess.py
@@ -31,7 +31,9 @@ from elbepack.validate import error_log_to_strings
 # list of sections that are allowed to exists multiple times before
 # preprocess and that childrens are merge into one section during preprocess
 mergepaths = ['//target/finetuning',
+              '//target/hostsdk-pkg-list',
               '//target/pkg-list',
+              '//project/mirror/url-list',
               '//project/buildimage/pkg-list']
 
 

--- a/newsfragments/+mergepaths.feature.rst
+++ b/newsfragments/+mergepaths.feature.rst
@@ -1,0 +1,1 @@
+Extend mergepaths list to allow multiple hostsdk-pkg-list and url-list elements.


### PR DESCRIPTION
Add hostsdk-pkg-list and url-list node to the mergepaths list to allow multiple instances like for pkg-list and finetuning. With that extend the capabilities of using XML includes and variants.