### PR TITLE
elbepack: cdroms: use source name of pkgs with on_src_cd attribute

### DIFF
--- a/elbepack/aptpkgutils.py
+++ b/elbepack/aptpkgutils.py
@@ -188,7 +188,7 @@ def parse_built_using(value):
         yield package, version
 
 
-def get_corresponding_source_packages(cache, pkg_lst=None):
+def get_corresponding_source_packages(cache, pkg_lst=None, include_built_using=True):
 
     if pkg_lst is None:
         pkg_lst = {p.name for p in cache if p.is_installed}
@@ -203,8 +203,9 @@ def get_corresponding_source_packages(cache, pkg_lst=None):
 
         src_set.add((version.source_name, version.source_version))
 
-        for name, ver in parse_built_using(version.record.get('Built-Using')):
-            src_set.add((name, ver))
+        if include_built_using:
+            for name, ver in parse_built_using(version.record.get('Built-Using')):
+                src_set.add((name, ver))
 
     return list(src_set)
 

--- a/elbepack/cdroms.py
+++ b/elbepack/cdroms.py
@@ -22,6 +22,7 @@ CDROM_SIZE = 640 * 1000 * 1000
 
 def add_source_pkg(repo, component, cache, pkg, version, forbid):
     if pkg in forbid:
+        logging.info("Ignoring source package %s", pkg)
         return
     pkg_id = f'{pkg}-{version}'
     try:
@@ -42,12 +43,12 @@ def mk_source_cdrom(components, codename,
 
     os.makedirs('/var/cache/elbe/sources', exist_ok=True)
 
-    forbiddenPackages = []
+    forbidden_packages = []
     if xml is not None and xml.has('target/pkg-list'):
         for i in xml.node('target/pkg-list'):
             try:
                 if i.tag == 'pkg' and i.et.attrib['on_src_cd'] == 'False':
-                    forbiddenPackages.append(i.text('.').strip())
+                    forbidden_packages.append(i.text('.').strip())
             except KeyError:
                 pass
 
@@ -56,6 +57,11 @@ def mk_source_cdrom(components, codename,
     for component in components.keys():
         rfs, cache, pkg_lst = components[component]
         logging.info('Adding %s component', component)
+
+        forbidden_src_packages = set()
+        for name, _ in cache.get_corresponding_source_packages(forbidden_packages, include_built_using=False):
+            forbidden_src_packages.add(name)
+
         rfs.mkdir_p('/var/cache/elbe/sources')
         repo = CdromSrcRepo(codename, init_codename,
                             os.path.join(target, f'srcrepo-{component}'),
@@ -64,14 +70,14 @@ def mk_source_cdrom(components, codename,
         for pkg, version in pkg_lst:
             add_source_pkg(repo, component,
                            cache, pkg, version,
-                           forbiddenPackages)
+                           forbidden_src_packages)
 
         if component == 'main' and xml is not None:
             for p in xml.node('debootstrappkgs'):
                 pkg = XMLPackage(p)
                 srcpkgs = cache.get_corresponding_source_packages([pkg])
                 for srcpkg, srcpkg_ver in srcpkgs:
-                    add_source_pkg(repo, component, cache, srcpkg, srcpkg_ver, forbiddenPackages)
+                    add_source_pkg(repo, component, cache, srcpkg, srcpkg_ver, forbidden_src_packages)
 
     # elbe fetch_initvm_pkgs has downloaded all sources to
     # /var/cache/elbe/sources

--- a/elbepack/rpcaptcache.py
+++ b/elbepack/rpcaptcache.py
@@ -260,8 +260,8 @@ class RPCAPTCache(InChRootObject):
     def get_pkg(self, pkgname):
         return APTPackage(self.cache[pkgname])
 
-    def get_corresponding_source_packages(self, pkg_lst=None):
-        return get_corresponding_source_packages(self.cache, pkg_lst)
+    def get_corresponding_source_packages(self, pkg_lst=None, *, include_built_using=True):
+        return get_corresponding_source_packages(self.cache, pkg_lst, include_built_using)
 
     def download_binary(self, pkgname, path, version=None):
         p = self.cache[pkgname]

--- a/newsfragments/+source-exclude.bugfix.rst
+++ b/newsfragments/+source-exclude.bugfix.rst
@@ -1,0 +1,1 @@
+Resolve corresponding source package names for exclude source CD.


### PR DESCRIPTION
Resolve the corresponding source name of the binary packages where the XML attribute on_src_cd="False" is set.
Until now the binary name was used, which doesn't work when the source name differs to the binary name of the package. The forbiddenPackages list, containing the binary package names will be resolved and the corresponding source package names are stored in the forbiddenSrcPackages list which is then used for the comparison inside the add_source_pkg function.