### PR TITLE
elbepack: add /lib64 to target sysroot

### DIFF
--- a/elbepack/elbeproject.py
+++ b/elbepack/elbeproject.py
@@ -228,7 +228,9 @@ class ElbeProject:
             './usr/lib/*.a',
             './usr/lib/*.so',
             './usr/lib/*.so.*',
-            './usr/lib/' + triplet]
+            './usr/lib/' + triplet,
+            './usr/lib64/*.so.*',
+            ]
 
         return paths
 
@@ -289,6 +291,7 @@ class ElbeProject:
 
         with self.sysrootenv.rfs:
             chroot(self.sysrootpath, ['/usr/bin/symlinks', '-cr', '/usr/lib'])
+            chroot(self.sysrootpath, ['/usr/bin/symlinks', '-cr', '/usr/lib64'])
 
         paths = self.get_sysroot_paths()
 
@@ -300,6 +303,9 @@ class ElbeProject:
         if os.path.islink(self.sysrootpath + '/lib'):
             with open(sysrootfilelist, 'a') as filelist_fd:
                 filelist_fd.write('./lib\n')
+        if os.path.islink(self.sysrootpath + '/lib64'):
+            with open(sysrootfilelist, 'a') as filelist_fd:
+                filelist_fd.write('./lib64\n')
         if os.path.islink(self.sysrootpath + '/sbin'):
             with open(sysrootfilelist, 'a') as filelist_fd:
                 filelist_fd.write('./sbin\n')


### PR DESCRIPTION
The `libc.so` is a linker script having `AS_NEEDED ( /lib64/ld-linux-x86-64.so.2 )`. While on the sysroot host this gets fixed by the relocation script, on the target it stays untouched. However, when a user links the C library by directly mentioning the path to `sysroot/target/usr/lib/x86_64-linux-gnu/libc.so` it gets the error that `/lib64/ld-linux-x86-64.so.2` can't be found. Or worse, it links using the user environment. On the other hand, this does not happen when using `-lc` or letting `gcc` pick the right libc because it fetches the one from the sysroot host. This is not a problem on x86_64 because both host and target sysroot share the same binaries.

This patch adds the `/lib64` symbolic link to the sysroot target.