### PR TITLE
elbepack: default-init: Re-add ubuntu-keyring

### DIFF
--- a/elbepack/init/default-init.xml
+++ b/elbepack/init/default-init.xml
@@ -87,6 +87,7 @@ lffHf8U7HFvRg+zm
 		<suite>bookworm</suite>
 		<pkg-list>
 			<pkg>openssh-server</pkg>
+			<pkg>ubuntu-keyring</pkg>
 			<pkg>debootstrap</pkg>
 			<pkg>reprepro</pkg>
 		</pkg-list>


### PR DESCRIPTION
ubuntu-keyring was removed from elbe because of Debian bug 929165. This bug is solved since version 2023.11.29 of ubuntu-keyring. This allows users to build ubuntu images more easily.

Link: https://bugs.debian.org/929165