### PR TITLE
elbepack: hdimg: enable passing environment variables to grub

### DIFF
--- a/elbepack/hdimg.py
+++ b/elbepack/hdimg.py
@@ -154,6 +154,11 @@ class grubinstaller202(grubinstaller_base):
         if '/' not in self.fs:
             return
 
+        # Extract environnement variable from user_args
+        env = {var.split('=')[0]: var.split('=')[1]
+               for var in user_args if "=" in var}
+        user_args = [item for item in user_args if "=" not in item]
+
         imagemnt = os.path.join(target, 'imagemnt')
         imagemntfs = Filesystem(imagemnt)
         with contextlib.ExitStack() as stack:
@@ -172,7 +177,7 @@ class grubinstaller202(grubinstaller_base):
                 imagemntfs.write_file('boot/grub/device.map', 0o644, f'(hd0) {loopdev}\n')
                 stack.callback(imagemntfs.remove, 'boot/grub/device.map')
 
-                chroot(imagemnt, ['update-grub2'])
+                chroot(imagemnt, ['update-grub2'], env_add=env)
 
                 if 'efi' in self.fw_type:
                     grub_tgt = next(t for t in self.fw_type if t.endswith('-efi'))

--- a/elbepack/schema/dbsfed.xsd
+++ b/elbepack/schema/dbsfed.xsd
@@ -1454,8 +1454,10 @@ SPDX-FileCopyrightText: Linutronix GmbH
       <element name="grub-install" type="rfs:string" minOccurs="0" maxOccurs="1">
         <annotation>
           <documentation>
-            Installs grub on this harddisk. The text content will be used as
-            additional command line arguments to Elbe's grub-install call.
+            Installs grub on this harddisk. The text content will be split
+            between additional command line arguments given to Elbe's
+            grub-install call and environment variables will be given to
+            update-grub2.
           </documentation>
         </annotation>
       </element>
@@ -1536,8 +1538,10 @@ SPDX-FileCopyrightText: Linutronix GmbH
       <element name="grub-install" type="rfs:string" minOccurs="0" maxOccurs="1">
         <annotation>
           <documentation>
-            Installs grub on this harddisk. The text content will be used as
-            additional command line arguments to Elbe's grub-install call.
+            Installs grub on this harddisk. The text content will be split
+            between additional command line arguments given to Elbe's
+            grub-install call and environment variables will be given to
+            update-grub2.
           </documentation>
         </annotation>
       </element>


### PR DESCRIPTION
The update-grub2 script is customizable by passing environment variables; however, it was impossible to do so in Elbe.

This commit enables passing environment variables to the update-grub2 script in addition to the additional parameters for install-grub. 
Every word containing an equal sign will be interpreted as an environment variable.

This is particularly useful for example when you want to force Grub to use PARTUUID (mandatory when booting without an initramfs).