### PR TITLE
contrib: dockerfile: Update to bookworm and drop libvirt compatibility

### DIFF
--- a/contrib/dockerfile/Dockerfile.in
+++ b/contrib/dockerfile/Dockerfile.in
@@ -4,25 +4,19 @@
 # SPDX-FileCopyrightText: 2018 Linutronix GmbH
 
 # This Dockerfile generate a image for the elbe buildsystem
-FROM debian:bullseye
+FROM debian:trixie-slim
 
 USER root
 ENV DEBIAN_FRONTEND noninteractive
 
-# use a sources.list including backports and security
-RUN echo "deb http://deb.debian.org/debian bullseye-backports main" >> /etc/apt/sources.list; \
-    echo "deb http://deb.debian.org/debian-security bullseye-security main"   >> /etc/apt/sources.list
-
 # update, upgrade and install elbe runtime-dependencies
-RUN apt-get update -y ;\
-    apt-get install -y --no-install-recommends \
+RUN apt-get update -y
+RUN apt-get install -y --no-install-recommends \
                     -o Dpkg::Options::="--force-confnew" \
-        systemd \
         ca-certificates \
         sudo \
         vim-nox \
         elbe-archive-keyring \
-        software-properties-common \
         gnupg \
         python3-setuptools \
         python3-yaml \
@@ -61,14 +55,6 @@ RUN useradd -d /home/elbe -l -U -G kvm-elbe,libvirt -m -s /bin/bash -u @USERID@ 
 RUN echo "root:elbe" | chpasswd
 RUN echo "elbe:elbe" | chpasswd
 
-RUN rm -f /lib/systemd/system/multi-user.target.wants/*;\
-    rm -f /etc/systemd/system/*.wants/*;\
-    rm -f /lib/systemd/system/local-fs.target.wants/*; \
-    rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
-    rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
-    rm -f /lib/systemd/system/basic.target.wants/*;\
-    rm -f /lib/systemd/system/anaconda.target.wants/*;
-
 VOLUME [ "/sys/fs/cgroup" ]
 VOLUME [ "/elbe" ]
 VOLUME [ "/var/cache/elbe" ]
@@ -77,11 +63,5 @@ VOLUME [ "/var/cache/elbe" ]
 RUN echo "%elbe  ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/elbegrp
 RUN chmod 0440 /etc/sudoers.d/elbegrp
 
-# run qemu as root
-RUN echo 'user = "root"' >> /etc/libvirt/qemu.conf
-RUN echo 'group = "root"' >> /etc/libvirt/qemu.conf
 
-# run libvirt in systemd on startup
-RUN systemctl enable libvirtd
-
-CMD [ "/lib/systemd/systemd" ]
+CMD [ "/bin/bash" ]

--- a/contrib/dockerfile/Makefile
+++ b/contrib/dockerfile/Makefile
@@ -8,6 +8,18 @@ CONTAINERNAME ?= elbe-devel
 KVMGID ?= $(shell ls -n /dev/kvm | awk '{ print $$4 }')
 UID ?= $(shell id -u)
 
+# Common docker run options
+DOCKER_RUN_OPTS = \
+	--cap-add SYS_ADMIN \
+	--security-opt seccomp:unconfined \
+	--security-opt apparmor:unconfined \
+	--group-add kvm \
+	--device /dev/kvm \
+	--device /dev/fuse \
+	--rm \
+	--interactive \
+	--tty
+
 # docker commands
 build:
 	test -c /dev/kvm  || ( echo "/dev/kvm not found" && false )
@@ -23,21 +35,23 @@ build:
 	             -t $(IMAGENAME) .
 	rm Dockerfile
 
-start:
+start-devel:
 	docker ps | grep $(CONTAINERNAME)$$ || \
-	docker run --name $(CONTAINERNAME) -d \
-		-e container=docker \
+	docker run --name $(CONTAINERNAME) \
 		-e http_proxy=$(http_proxy) \
 		-e https_proxy=$(https_proxy) \
 		-e no_proxy=$(no_proxy) \
-		-v $(realpath ../../.):/elbe -w /elbe\
-		-v /sys/fs/cgroup:/sys/fs/cgroup:ro \
-		--cap-add SYS_ADMIN \
-		--security-opt seccomp:unconfined \
-		--security-opt apparmor:unconfined \
-		--group-add kvm \
-		--device /dev/kvm \
-		--device /dev/fuse \
+		-v $(realpath ../../.):/var/cache/elbe/devel -w /var/cache/elbe/devel \
+		$(DOCKER_RUN_OPTS) \
+		$(IMAGENAME)
+
+start:
+	docker ps | grep $(CONTAINERNAME)$$ || \
+	docker run --name $(CONTAINERNAME) \
+		-e http_proxy=$(http_proxy) \
+		-e https_proxy=$(https_proxy) \
+		-e no_proxy=$(no_proxy) \
+		$(DOCKER_RUN_OPTS) \
 		$(IMAGENAME)
 
 stop:

--- a/contrib/dockerfile/README.md
+++ b/contrib/dockerfile/README.md
@@ -27,14 +27,15 @@ You need docker installed, a running docker service and `make` installed.
 ## usage
 
 A `Makefile` with some handy targets are provided. Per default the image name
-is `elbe-image` and a started container name is `elbe`. This names are
+is `elbe-devel-image` and a started container name is `elbe-devel`. This names are
 changeable via `IMAGENAME` and `CONTAINERNAME` environment variables.
 
 * `build`: build the image
-* `start` start a container, mounts the elbe git-archive to `/elbe`
+* `start` start a container, and use packaged elbe
+* `start-devel` start a container, mounts the elbe git-archive to `/var/cache/elbe`
 * `stop`: stop a running container
 * `stoprm`: stop and remove the container
-* `connect`: attach to a running container
+* `connect`: attach a new terminal to a running container
 
 After `connect` you can find the elbe git repository under `/elbe`.
 


### PR DESCRIPTION
The current container is running debian bullseye and is starting systemd to run libvirtd in background. This container is broken since some times.
This commit updates the dockerfile to run interactively, libvirt isn't supported in this version.
There are two launch options, start to run in production which will use the packaged version of Elbe and start-devel which will use the version of Elbe currently being used by the repository.