### PR TITLE
elbepack: always provide default packages in the SDK

### DIFF
--- a/elbepack/elbeproject.py
+++ b/elbepack/elbeproject.py
@@ -384,13 +384,12 @@ class ElbeProject:
             for p in self.xml.tgt.node('hostsdk-pkg-list'):
                 if p.tag == 'pkg':
                     host_pkglist.append(p.et.text.strip())
-        else:
-            try:
-                host_pkglist.append(self.xml.defs['sdkgccpkg'])
-            except KeyError:
-                raise UnsupportedSDKException(triplet)
+        try:
+            host_pkglist.append(self.xml.defs['sdkgccpkg'])
+        except KeyError:
+            raise UnsupportedSDKException(triplet)
 
-            host_pkglist.append('gdb-multiarch')
+        host_pkglist.append('gdb-multiarch')
 
         # build target sysroot including libs and headers for the target
         self.build_sysroot()


### PR DESCRIPTION
When the user does not provide any `<hostsdk-pkg-list>`, ELBE adds by default a few packages. However, these are not added when the user adds a package to `<hostsdk-pkg-list>`. In this second case, the user needs to explicitly add back the default packages.

If the philosophy is that users always get the default set of packages, then this patch fixes the problem.
