### PR TITLE
RFC: Fix for XML files with primary_key/host_key set

### DIFF
--- a/elbepack/elbeproject.py
+++ b/elbepack/elbeproject.py
@@ -873,6 +873,9 @@ class ElbeProject:
                 '--aptconfdir', os.path.join(self.builddir, 'aptconfdir'),
                 '--debootstrapopts', '--include=git,gnupg', *no_check_gpg, *keyring])
 
+        if debootstrap_key_path:
+            os.remove(debootstrap_key_path)
+
     def sync_xml_to_disk(self):
         try:
             sourcexmlpath = os.path.join(self.builddir, 'source.xml')


### PR DESCRIPTION
We have migrated from using Debian upstream repos to using our own snapshots, which are then signed with a dedicated key. Upon using `primary_key` in the XML, we noticed that `elbe pbuilder create` was failing.

This is a RFC. I'm not yet that comfortable with the codebase to say that this is the best solution. But at least for us it fixes the problem.