### PR TITLE
elbepack: init: forward ssh port when using qemu

### DIFF
--- a/elbepack/init/Makefile.mako
+++ b/elbepack/init/Makefile.mako
@@ -142,7 +142,7 @@ run_qemu:
 		-device virtio-net-pci,netdev=user.0 \
 		-drive file=$(INITVM),if=$(HD_TYPE),bus=1,unit=0 \
 		-no-reboot \
-		-netdev user,ipv4=on,id=user.0,hostfwd=tcp::7587-:7588${fwd} \
+		-netdev user,ipv4=on,id=user.0,hostfwd=tcp::7587-:7588,hostfwd=tcp::5022-:22${fwd} \
 		-m $(MEMSIZE) \
 		-usb \
 		-smp $(SMP)


### PR DESCRIPTION
Currently, the ssh port isn't exported by default which makes the `elbe initvm sync` and `elbe initvm ssh` unusable without manual port forwarding.

Adds default port forwarding for ssh port (22) to the default port elbe is looking for to sync and ssh into (5022).