### PR TITLE
dbsfed.xsd: remove artifacts from old documentation

### DIFF
--- a/elbepack/schema/dbsfed.xsd
+++ b/elbepack/schema/dbsfed.xsd
@@ -1133,7 +1133,7 @@ SPDX-FileCopyrightText: Linutronix GmbH
       <element name="pkg-blacklist" type="rfs:blacklist" minOccurs="0" maxOccurs="1">
         <annotation>
           <documentation>
-            avoid installation of packages into sysroot or target
+            avoid installation of packages into sysroot
           </documentation>
         </annotation>
       </element>


### PR DESCRIPTION
Since commit 68b34c9fa, it was abandonned to support target blacklisting, to align on what is currently supported, this commit slightly modify the documentation to remove the mention of target blacklisting.