### PR TITLE
elbepack: aptpkgutils: implement recursive package blacklisting in diet builds

### DIFF
--- a/elbepack/aptpkgutils.py
+++ b/elbepack/aptpkgutils.py
@@ -67,16 +67,20 @@ def getdeps(pkg):
             yield d.name
 
 
-def getalldeps(c, pkgname):
-    retval = []
+def getalldeps(c, pkgname, blacklist=()):
+    retval = [pkgname]
     togo = [pkgname]
 
     while togo:
         pp = togo.pop()
+        if pp in blacklist:
+            continue
         pkg = c[pp]
 
         for p in getdeps(pkg.candidate):
             if p in retval:
+                continue
+            if p in blacklist:
                 continue
             if p not in c:
                 continue

--- a/elbepack/rpcaptcache.py
+++ b/elbepack/rpcaptcache.py
@@ -224,8 +224,8 @@ class RPCAPTCache(InChRootObject):
                           ElbeInstallProgress(fileno=sys.stdout.fileno()))
         self.cache.open(progress=ElbeOpProgress())
 
-    def get_dependencies(self, pkgname):
-        deps = getalldeps(self.cache, pkgname)
+    def get_dependencies(self, pkgname, blacklist):
+        deps = getalldeps(self.cache, pkgname, blacklist)
         return [APTPackage(self.cache[p]) for p in deps]
 
     def get_installed_pkgs(self, section='all'):

--- a/elbepack/schema/dbsfed.xsd
+++ b/elbepack/schema/dbsfed.xsd
@@ -3094,6 +3094,13 @@ SPDX-FileCopyrightText: Linutronix GmbH
       </documentation>
     </annotation>
     <sequence>
+        <element name="target" type="rfs:pkg-list" minOccurs="0" maxOccurs="unbounded">
+          <annotation>
+            <documentation>
+              avoid installing the specified packages into the target (only works in diet mode)
+            </documentation>
+          </annotation>
+        </element>
         <element name="sysroot" type="rfs:pkg-list" minOccurs="0" maxOccurs="unbounded">
           <annotation>
             <documentation>


### PR DESCRIPTION
Implements package blacklisting for diet builds, this allows the user to create a list of packages to exclude from the target. This will recursively avoid installing a package and all its dependencies on the target even if this package comes as a dependency of another package.
This must be carefully used as it can create packages with lacking dependencies.

This pull-request conflict with https://github.com/Linutronix/elbe/pull/451 that removes the part of the documentation on target package blacklisting