### PR TITLE
tests/simple-validation-image-test.py: compare permissions with original file

### DIFF
--- a/newsfragments/+umask.bugfix.rst
+++ b/newsfragments/+umask.bugfix.rst
@@ -1,0 +1,1 @@
+Do not use hardcoded umask for archive content in simple-validation-image-test.

--- a/tests/simple-validation-image-test.py
+++ b/tests/simple-validation-image-test.py
@@ -208,8 +208,13 @@ def _test_archive(root):
     archive_file = root.joinpath('opt', 'archive-file')
     assert archive_file.is_file()
 
+    orig_file = pathlib.Path(__file__).parent.joinpath(
+        'simple-validation-image-archive1', 'opt', 'archive-file')
+    assert orig_file.is_file()
+
     archive_file_stat = archive_file.stat()
-    assert archive_file_stat.st_mode & 0o777 == 0o644
+    orig_file_stat = orig_file.stat()
+    assert archive_file_stat.st_mode & 0o777 == orig_file_stat.st_mode & 0o777
     assert archive_file_stat.st_uid == 0
     assert archive_file_stat.st_gid == 0
 


### PR DESCRIPTION
Hardcoded value of 644 was found to be problematic on systems where umask is set to 0002, which causes the file to be created with permissions of 664.