### PR TITLE
elbepack: add support for base images

### DIFF
--- a/elbepack/asyncworker.py
+++ b/elbepack/asyncworker.py
@@ -143,11 +143,12 @@ class BuildChrootTarJob(AsyncWorkerJob):
 
 
 class BuildJob(AsyncWorkerJob):
-    def __init__(self, project, build_bin, build_src, skip_pbuilder):
+    def __init__(self, project, build_bin, build_src, skip_pbuilder, base_image_path):
         super().__init__(project)
         self.build_bin = build_bin
         self.build_src = build_src
         self.skip_pbuilder = skip_pbuilder
+        self.base_image_path = base_image_path
 
     def enqueue(self, queue, db):
         db.set_busy(self.project.builddir,
@@ -164,7 +165,8 @@ class BuildJob(AsyncWorkerJob):
             self.project.build(skip_pkglist=False,
                                build_bin=self.build_bin,
                                build_sources=self.build_src,
-                               skip_pbuild=self.skip_pbuilder)
+                               skip_pbuild=self.skip_pbuilder,
+                               base_image_path=self.base_image_path)
         except (DebootstrapException, AptCacheCommitError, AptCacheUpdateError) as e:
             if isinstance(e, DebootstrapException):
                 err = 'Debootstrap failed to install the base rootfilesystem.'

--- a/elbepack/daemons/soap/esoap.py
+++ b/elbepack/daemons/soap/esoap.py
@@ -162,10 +162,10 @@ class ESoap (ServiceBase):
     def build_cdroms(self, builddir, build_bin, build_src):
         self.app.pm.build_cdroms(builddir, build_bin, build_src)
 
-    @rpc(String, Boolean, Boolean, Boolean)
-    def build(self, builddir, build_bin, build_src, skip_pbuilder):
+    @rpc(String, Boolean, Boolean, Boolean, String)
+    def build(self, builddir, build_bin, build_src, skip_pbuilder, base_image_path):
 
-        self.app.pm.build_project(builddir, build_bin, build_src, skip_pbuilder)
+        self.app.pm.build_project(builddir, build_bin, build_src, skip_pbuilder, base_image_path)
 
     @rpc(String, Boolean, Boolean, String)
     def build_pbuilder(self, builddir, cross, noccache, ccachesize):
@@ -193,6 +193,20 @@ class ESoap (ServiceBase):
     @rpc(String)
     def finish_cdrom(self, builddir):
         self.app.pm.set_upload_cdrom(builddir, ValidationMode.NO_CHECK)
+
+    @rpc(String, _returns=String)
+    def start_base_image(self, builddir):
+        fname = 'uploaded_base_image.img'
+
+        with open(os.path.join(builddir, fname), 'w'):
+            # Now write empty File
+            pass
+
+        return fname
+
+    @rpc(String)
+    def finish_base_image(self, builddir):
+        pass
 
     @rpc(String, _returns=String)
     def start_pdebuild(self, builddir):

--- a/elbepack/efilesystem.py
+++ b/elbepack/efilesystem.py
@@ -480,6 +480,10 @@ class TargetFs(ChRootFilesystem):
                 options = self.xml.text('target/package/tar/options')
             _make_tarball(options, targz_name)
 
+        if self.xml.has('target/package/base-image'):
+            targz_name = self.xml.text('target/package/base-image/name')
+            _make_tarball('', targz_name)
+
         if self.xml.has('target/package/cpio'):
             oldwd = os.getcwd()
             cpio_name = self.xml.text('target/package/cpio/name')

--- a/elbepack/efilesystem.py
+++ b/elbepack/efilesystem.py
@@ -443,6 +443,23 @@ class TargetFs(ChRootFilesystem):
             f.close()
 
     def part_target(self, targetdir, grub_version, grub_fw_type):
+
+        def _make_tarball(options, targz_name):
+            try:
+                cmd = 'tar cfz %(dest)s/%(fname)s -C %(sdir)s %(options)s .'
+                args = dict(
+                    options=options,
+                    dest=targetdir,
+                    fname=targz_name,
+                    sdir=self.fname('')
+                )
+                do(cmd % args)
+                # only append filename if creating tarball was successful
+                self.images.append(targz_name)
+            except subprocess.CalledProcessError:
+                # error was logged; continue creating cpio image
+                pass
+
         from elbepack.hdimg import do_hdimg
 
         # create target images and copy the rfs into them
@@ -458,23 +475,10 @@ class TargetFs(ChRootFilesystem):
 
         if self.xml.has('target/package/tar'):
             targz_name = self.xml.text('target/package/tar/name')
-            try:
-                options = ''
-                if self.xml.has('target/package/tar/options'):
-                    options = self.xml.text('target/package/tar/options')
-                cmd = 'tar cfz %(dest)s/%(fname)s -C %(sdir)s %(options)s .'
-                args = dict(
-                    options=options,
-                    dest=targetdir,
-                    fname=targz_name,
-                    sdir=self.fname('')
-                )
-                do(cmd % args)
-                # only append filename if creating tarball was successful
-                self.images.append(targz_name)
-            except subprocess.CalledProcessError:
-                # error was logged; continue creating cpio image
-                pass
+            options = ''
+            if self.xml.has('target/package/tar/options'):
+                options = self.xml.text('target/package/tar/options')
+            _make_tarball(options, targz_name)
 
         if self.xml.has('target/package/cpio'):
             oldwd = os.getcwd()

--- a/elbepack/elbeproject.py
+++ b/elbepack/elbeproject.py
@@ -597,7 +597,8 @@ class ElbeProject:
         if not self.has_full_buildenv():
             do(['mkdir', '-p', self.chrootpath])
             self.buildenv = BuildEnv(self.xml, self.chrootpath,
-                                     build_sources=build_sources, clean=True)
+                                     build_sources=build_sources, clean=True,
+                                     base_image_path=base_image_path)
             skip_pkglist = False
 
         # Import keyring

--- a/elbepack/elbeproject.py
+++ b/elbepack/elbeproject.py
@@ -577,7 +577,7 @@ class ElbeProject:
                     validation.error(str(e))
 
     def build(self, build_bin=False, build_sources=False, cdrom_size=None,
-              skip_pkglist=False, skip_pbuild=False):
+              skip_pkglist=False, skip_pbuild=False, base_image_path=None):
 
         # Write the log header
         self.write_log_header()

--- a/elbepack/initvmaction.py
+++ b/elbepack/initvmaction.py
@@ -90,17 +90,17 @@ def _attach(args):
     _initvm_from_args(args).attach()
 
 
-def _submit_with_repodir_and_dl_result(control, xmlfile, cdrom, args):
+def _submit_with_repodir_and_dl_result(control, xmlfile, cdrom, base_image, args):
     fname = f'elbe-repodir-{time.time_ns()}.xml'
     preprocess_xmlfile = os.path.join(os.path.dirname(xmlfile), fname)
     try:
         with Repodir(xmlfile, preprocess_xmlfile):
-            _submit_and_dl_result(control, preprocess_xmlfile, cdrom, args)
+            _submit_and_dl_result(control, preprocess_xmlfile, cdrom, base_image, args)
     except RepodirError as err:
         raise with_cli_details(err, 127, 'elbe repodir failed')
 
 
-def _submit_and_dl_result(control, xmlfile, cdrom, args):
+def _submit_and_dl_result(control, xmlfile, cdrom, base_image, args):
 
     with preprocess_file(xmlfile, variants=args.variants, sshport=args.sshport,
                          soapport=args.soapport) as xmlfile:
@@ -117,7 +117,14 @@ def _submit_and_dl_result(control, xmlfile, cdrom, args):
         control.set_cdrom(prjdir, cdrom)
         print('Upload finished')
 
-    control.service.build(prjdir, args.build_bin, args.build_sources, bool(cdrom))
+    uploaded_base_image_path = None
+    if base_image is not None:
+        print('Uploading base image. This might take a while')
+        uploaded_base_image_path = control.set_base_image(prjdir, base_image)
+        print('Upload finished')
+
+    control.service.build(prjdir, args.build_bin, args.build_sources, bool(cdrom),
+                          uploaded_base_image_path)
 
     print('Build started, waiting till it finishes')
 
@@ -278,6 +285,9 @@ def _add_submit_arguments(f):
     f = add_argument('--build-sdk', dest='build_sdk', action='store_true', default=False,
                      help="Also make 'initvm submit' build an SDK.")(f)
 
+    f = add_argument('--base-image', dest='base_image',
+                     help='Use a base image instead of debootstrap (experimental)')(f)
+
     return f
 
 
@@ -368,7 +378,7 @@ def _create(args):
         elif cdrom is not None:
             xmlfile = tmp.fname('source.xml')
 
-        _submit_with_repodir_and_dl_result(initvm.control, xmlfile, cdrom, args)
+        _submit_with_repodir_and_dl_result(initvm.control, xmlfile, cdrom, args.base_image, args)
 
 
 @_add_initvm_from_args_arguments
@@ -393,7 +403,7 @@ def _submit(args):
     else:
         args.parser.error('Unknown file ending (use either xml or iso)')
 
-    _submit_with_repodir_and_dl_result(initvm.control, xmlfile, cdrom, args)
+    _submit_with_repodir_and_dl_result(initvm.control, xmlfile, cdrom, args.base_image, args)
 
 
 @add_argument_sshport

--- a/elbepack/projectmanager.py
+++ b/elbepack/projectmanager.py
@@ -111,10 +111,11 @@ class ProjectManager:
             builddir,
             build_bin,
             build_src,
-            skip_pbuilder):
+            skip_pbuilder,
+            base_image_path):
         ep = self.open_project(builddir, allow_busy=False)
         self.worker.enqueue(BuildJob(ep, build_bin, build_src,
-                                     skip_pbuilder))
+                                     skip_pbuilder, base_image_path))
 
     def update_pbuilder(self, builddir):
         ep = self.open_project(builddir, allow_busy=False)

--- a/elbepack/rfs.py
+++ b/elbepack/rfs.py
@@ -73,25 +73,27 @@ class BuildEnv:
         if clean:
             self.rfs.rmtree('')
 
+        self.fresh_debootstrap = False
+        self.need_dumpdebootstrap = False
         # TODO think about reinitialization if elbe_version differs
         if not self.rfs.isfile('etc/elbe_version'):
-            # avoid starting daemons inside the buildenv
-            self.rfs.mkdir_p('usr/sbin')
-            # grub-legacy postinst will fail if /boot/grub does not exist
-            self.rfs.mkdir_p('boot/grub')
-            self.rfs.write_file(
-                'usr/sbin/policy-rc.d',
-                0o755,
-                '#!/bin/sh\nexit 101\n')
-            self.debootstrap(arch)
-            self.fresh_debootstrap = True
-            self.need_dumpdebootstrap = True
-        else:
-            self.fresh_debootstrap = False
-            self.need_dumpdebootstrap = False
+            self.prepare_and_run_debootstrap()
 
         self.initialize_dirs(build_sources=build_sources)
         create_apt_prefs(self.xml, self.rfs)
+
+    def prepare_and_run_debootstrap(self):
+        # avoid starting daemons inside the buildenv
+        self.rfs.mkdir_p('usr/sbin')
+        # grub-legacy postinst will fail if /boot/grub does not exist
+        self.rfs.mkdir_p('boot/grub')
+        self.rfs.write_file(
+            'usr/sbin/policy-rc.d',
+            0o755,
+            '#!/bin/sh\nexit 101\n')
+        self.debootstrap(self.arch)
+        self.fresh_debootstrap = True
+        self.need_dumpdebootstrap = True
 
     def cdrom_umount(self):
         if self.xml.prj.has('mirror/cdrom'):

--- a/elbepack/rfs.py
+++ b/elbepack/rfs.py
@@ -6,6 +6,8 @@
 import logging
 import os
 import subprocess
+import sys
+import tarfile
 from urllib.parse import urlsplit
 
 from elbepack.efilesystem import ChRootFilesystem, dpkg_architecture
@@ -60,7 +62,8 @@ class DebootstrapException (Exception):
 
 class BuildEnv:
     def __init__(self, xml, path, build_sources=False,
-                 clean=False, arch='default', hostsysroot=False):
+                 clean=False, arch='default', hostsysroot=False,
+                 base_image_path=None):
 
         self.xml = xml
         self.path = path
@@ -77,7 +80,20 @@ class BuildEnv:
         self.need_dumpdebootstrap = False
         # TODO think about reinitialization if elbe_version differs
         if not self.rfs.isfile('etc/elbe_version'):
-            self.prepare_and_run_debootstrap()
+            use_base_image = self.xml.has('target/debootstrap/type') and \
+                self.xml.text('target/debootstrap/type') == 'base-image'
+            if use_base_image:
+                if base_image_path:
+                    self.copy_base_image(base_image_path)
+                else:
+                    raise Exception('XML specifies the use of base image, '
+                                    'but none has been provided on the command line '
+                                    '(use --base-image "path/to/image")')
+            else:
+                if base_image_path:
+                    raise Exception('Base image was provided on the command line,'
+                                    ' but XML file specifies the use of debootstap')
+                self.prepare_and_run_debootstrap()
 
         self.initialize_dirs(build_sources=build_sources)
         create_apt_prefs(self.xml, self.rfs)
@@ -94,6 +110,22 @@ class BuildEnv:
         self.debootstrap(self.arch)
         self.fresh_debootstrap = True
         self.need_dumpdebootstrap = True
+
+    def copy_base_image(self, base_image_file):
+        def abspath_filter(member, path):
+            if os.path.isabs(member.name):
+                raise Exception('The base image archive contains a member with an absolute path:'
+                                f' {member.name}. All members must be relative paths.')
+            return member
+
+        with tarfile.open(base_image_file) as tar:
+            logging.info(f'Extracting {base_image_file} into {self.path}')
+            if not hasattr(tarfile, 'data_filter'):
+                raise Exception(f'This python installation ({sys.version}) does not support tar'
+                                ' filters (available starting from 3.12 and backported to latest'
+                                ' point releases in 3.8 to 3.11)')
+            tarfile.extraction_filter = abspath_filter
+            tar.extractall(path=self.path, numeric_owner=True)
 
     def cdrom_umount(self):
         if self.xml.prj.has('mirror/cdrom'):

--- a/elbepack/schema/dbsfed.xsd
+++ b/elbepack/schema/dbsfed.xsd
@@ -1214,7 +1214,7 @@ SPDX-FileCopyrightText: Linutronix GmbH
       <element name="type" type="rfs:bootstrap_type" minOccurs="0" maxOccurs="1">
         <annotation>
           <documentation>
-            Bootstrapper type. Either debootstrap (the default) or mmdebstrap.
+            Bootstrapper type. Either debootstrap (the default) or mmdebstrap or (experimental) base-image.
           </documentation>
         </annotation>
       </element>
@@ -1225,6 +1225,7 @@ SPDX-FileCopyrightText: Linutronix GmbH
     <restriction base="string">
       <enumeration value="debootstrap" />
       <enumeration value="mmdebstrap" />
+      <enumeration value="base-image" />
     </restriction>
   </simpleType>
 

--- a/elbepack/schema/dbsfed.xsd
+++ b/elbepack/schema/dbsfed.xsd
@@ -1802,7 +1802,7 @@ SPDX-FileCopyrightText: Linutronix GmbH
   <complexType name="package">
     <annotation>
       <documentation>
-         list of packages, each contains the hole rootfilesystem
+         list of packages, each contains the whole rootfilesystem
       </documentation>
     </annotation>
     <all>
@@ -1810,6 +1810,13 @@ SPDX-FileCopyrightText: Linutronix GmbH
         <annotation>
           <documentation>
              tar package of the rootfilesystem
+          </documentation>
+        </annotation>
+      </element>
+      <element name="base-image" type="rfs:base-image" minOccurs="0">
+        <annotation>
+          <documentation>
+             base image package of the rootfilesystem (experimental)
           </documentation>
         </annotation>
       </element>
@@ -1849,6 +1856,24 @@ SPDX-FileCopyrightText: Linutronix GmbH
         <annotation>
           <documentation>
              options passed to the tar command
+          </documentation>
+        </annotation>
+      </element>
+    </all>
+    <attributeGroup ref="xml:specialAttrs"/>
+  </complexType>
+
+  <complexType name="base-image">
+    <annotation>
+      <documentation>
+         describes a base image package
+      </documentation>
+    </annotation>
+    <all>
+      <element name="name" type="rfs:string" minOccurs="0">
+        <annotation>
+          <documentation>
+             filename of the base image package
           </documentation>
         </annotation>
       </element>

--- a/elbepack/soapclient.py
+++ b/elbepack/soapclient.py
@@ -203,6 +203,12 @@ class ElbeSoapClient:
         self._upload_file(builddir, fname, cdrom_file)
         self.service.finish_cdrom(builddir)
 
+    def set_base_image(self, builddir, base_image_file):
+        fname = self.service.start_base_image(builddir)
+        self._upload_file(builddir, fname, base_image_file)
+        self.service.finish_base_image(builddir)
+        return os.path.join(builddir, fname)
+
     def get_files(self, builddir, outdir, *, pbuilder_only=False, wildcard=None):
         files = self.service.get_files(builddir)
 

--- a/newsfragments/+base-images.feature.rst
+++ b/newsfragments/+base-images.feature.rst
@@ -1,0 +1,1 @@
+(experimental) Add support for producing base images and using them to build extended images without relying on debootstrap.

--- a/tests/simple-validation-image-base.xml
+++ b/tests/simple-validation-image-base.xml
@@ -1,0 +1,57 @@
+<!--
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-FileCopyrightText: Linutronix GmbH
+-->
+<ns0:RootFileSystem xmlns:ns0="https://www.linutronix.de/projects/Elbe"
+		    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		    created="2009-05-20T08:50:56" revision="6"
+		    xsi:schemaLocation="https://www.linutronix.de/projects/Elbe dbsfed.xsd">
+
+	<project>
+		<name>simple-validation-image</name>
+		<version>1.0</version>
+		<suite>bookworm</suite>
+		<buildtype>amd64</buildtype>
+
+		<description>
+			Image used to test ELBE features
+		</description>
+
+		<mirror>
+			<primary_host>deb.debian.org</primary_host>
+			<primary_path>/debian</primary_path>
+			<primary_proto>http</primary_proto>
+			<primary_key>
+				-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+				mDMEY865UxYJKwYBBAHaRw8BAQdAd7Z0srwuhlB6JKFkcf4HU4SSS/xcRfwEQWzr
+				crf6AEq0SURlYmlhbiBTdGFibGUgUmVsZWFzZSBLZXkgKDEyL2Jvb2t3b3JtKSA8
+				ZGViaWFuLXJlbGVhc2VAbGlzdHMuZGViaWFuLm9yZz6IlgQTFggAPhYhBE1k/sEZ
+				wgKQZ9bnkfjSWFuHg9SBBQJjzrlTAhsDBQkPCZwABQsJCAcCBhUKCQgLAgQWAgMB
+				Ah4BAheAAAoJEPjSWFuHg9SBSgwBAP9qpeO5z1s5m4D4z3TcqDo1wez6DNya27QW
+				WoG/4oBsAQCEN8Z00DXagPHbwrvsY2t9BCsT+PgnSn9biobwX7bDDg==
+				=5NZE
+				-----END PGP PUBLIC KEY BLOCK-----
+			</primary_key>
+		</mirror>
+
+	</project>
+
+	<archivedir>simple-validation-image-archive1</archivedir>
+
+	<target>
+                <hostname>validation-image</hostname>
+                <package>
+                        <base-image>
+                                <name>base-rootfs.tgz</name>
+                        </base-image>
+                </package>
+
+		<pkg-list>
+			<pkg>unzip</pkg>
+			<pkg>linux-image-amd64</pkg>
+			<pkg>grub-pc</pkg>
+		</pkg-list>
+
+	</target>
+</ns0:RootFileSystem>

--- a/tests/simple-validation-image-extended.xml
+++ b/tests/simple-validation-image-extended.xml
@@ -1,0 +1,88 @@
+<!--
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-FileCopyrightText: Linutronix GmbH
+-->
+<ns0:RootFileSystem xmlns:ns0="https://www.linutronix.de/projects/Elbe"
+		    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		    created="2009-05-20T08:50:56" revision="6"
+		    xsi:schemaLocation="https://www.linutronix.de/projects/Elbe dbsfed.xsd">
+
+	<project>
+		<name>simple-validation-image</name>
+		<version>1.0</version>
+		<suite>bookworm</suite>
+		<buildtype>amd64</buildtype>
+
+		<description>
+			Image used to test ELBE features
+		</description>
+
+		<mirror>
+			<primary_host>deb.debian.org</primary_host>
+			<primary_path>/debian</primary_path>
+			<primary_proto>http</primary_proto>
+			<primary_key>
+				-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+				mDMEY865UxYJKwYBBAHaRw8BAQdAd7Z0srwuhlB6JKFkcf4HU4SSS/xcRfwEQWzr
+				crf6AEq0SURlYmlhbiBTdGFibGUgUmVsZWFzZSBLZXkgKDEyL2Jvb2t3b3JtKSA8
+				ZGViaWFuLXJlbGVhc2VAbGlzdHMuZGViaWFuLm9yZz6IlgQTFggAPhYhBE1k/sEZ
+				wgKQZ9bnkfjSWFuHg9SBBQJjzrlTAhsDBQkPCZwABQsJCAcCBhUKCQgLAgQWAgMB
+				Ah4BAheAAAoJEPjSWFuHg9SBSgwBAP9qpeO5z1s5m4D4z3TcqDo1wez6DNya27QW
+				WoG/4oBsAQCEN8Z00DXagPHbwrvsY2t9BCsT+PgnSn9biobwX7bDDg==
+				=5NZE
+				-----END PGP PUBLIC KEY BLOCK-----
+			</primary_key>
+		</mirror>
+
+	</project>
+
+	<archivedir>simple-validation-image-archive1</archivedir>
+
+	<target>
+		<hostname>validation-image</hostname>
+		<domain>elbe-ci</domain>
+		<passwd_hashed>!invalid</passwd_hashed>
+		<console>ttyS0,115200</console>
+
+                <debootstrap>
+                        <type>base-image</type>
+                </debootstrap>
+
+		<images>
+			<msdoshd>
+				<name>sda.img</name>
+				<size>1000MiB</size>
+				<grub-install />
+				<partition>
+					<size>remain</size>
+					<label>rfs</label>
+				</partition>
+			</msdoshd>
+		</images>
+
+		<fstab>
+			<bylabel>
+				<label>rfs</label>
+				<mountpoint>/</mountpoint>
+				<fs><type>ext4</type></fs>
+			</bylabel>
+		</fstab>
+
+		<pkg-list>
+			<pkg>zip</pkg>
+			<pkg>unzip</pkg>
+			<pkg>linux-image-amd64</pkg>
+			<pkg>grub-pc</pkg>
+		</pkg-list>
+
+		<finetuning>
+			<rm>var/cache/apt/archives/*.deb</rm>
+			<command>rm -r /var/lib/apt/lists/</command>
+		</finetuning>
+
+		<project-finetuning>
+			<set_packer packer="none">sda.img</set_packer>
+		</project-finetuning>
+	</target>
+</ns0:RootFileSystem>


### PR DESCRIPTION
This is very much a demo/proof-of-concept/starting point for discussion and further improvements. Particularly there is no documentation or tests, and the code contains several hardcoded assumptions (e.g. about the image format, partitions layout, etc.)

The code replaces the debootstrap step with mounting and copying the content of the base image instead, if base image is found in the xml spec.

I've also added two demonstration xmls, which are copies of simple validation image xml with some tweaks to allow staged image builds.
    
Demo:

```    
    $ ./elbe --stacktrace-on-error initvm submit --skip-build-bin --skip-build-sources tests/simple-validation-image-base.xml
    $ ./elbe --stacktrace-on-error initvm submit --skip-build-bin --skip-build-sources --base-image ./elbe-build-20260520-183738/sda.img tests/simple-validation-image-extended.xml
```