### PR TITLE
RFC: Unshare to avoid the need for explicit CAP_SYS_ADMIN

### DIFF
--- a/debian/python3-elbe-common.install
+++ b/debian/python3-elbe-common.install
@@ -40,6 +40,7 @@ usr/lib/python3.*/*-packages/elbepack/shellhelper.py
 usr/lib/python3.*/*-packages/elbepack/spdx.py
 usr/lib/python3.*/*-packages/elbepack/templates.py
 usr/lib/python3.*/*-packages/elbepack/treeutils.py
+usr/lib/python3.*/*-packages/elbepack/unshare.py
 usr/lib/python3.*/*-packages/elbepack/uuid7.py
 usr/lib/python3.*/*-packages/elbepack/validate.py
 usr/lib/python3.*/*-packages/elbepack/version.py

--- a/elbepack/efilesystem.py
+++ b/elbepack/efilesystem.py
@@ -15,10 +15,10 @@ import time
 
 from elbepack.filesystem import Filesystem
 from elbepack.fstab import fstabentry
-from elbepack.imgutils import mount
 from elbepack.licencexml import copyright_xml
 from elbepack.packers import default_packer
 from elbepack.shellhelper import chroot, do
+from elbepack.unshare import enter_chroot_inplace
 from elbepack.version import elbe_version
 
 
@@ -369,16 +369,6 @@ class ChRootFilesystem(ElbeFilesystem):
             for excursion in excursions
         ]
 
-        if self.path != '/':
-            self._exitstack.enter_context(
-                    mount(None, self.fname('/proc'), type='proc', log_output=False))
-            self._exitstack.enter_context(
-                    mount(None, self.fname('/sys'), type='sysfs', log_output=False))
-            self._exitstack.enter_context(
-                    mount('/dev', self.fname('/dev'), bind=True, log_output=False))
-            self._exitstack.enter_context(
-                    mount('/dev/pts', self.fname('/dev/pts'), bind=True, log_output=False))
-
         return self
 
     def __exit__(self, typ, value, traceback):
@@ -395,18 +385,8 @@ class ChRootFilesystem(ElbeFilesystem):
 
     def enter_chroot(self):
         assert not self.inchroot
-
-        os.environ['LANG'] = 'C'
-        os.environ['LANGUAGE'] = 'C'
-        os.environ['LC_ALL'] = 'C'
-
-        os.chdir(self.path)
+        enter_chroot_inplace(self.path)
         self.inchroot = True
-
-        if self.path == '/':
-            return
-
-        os.chroot(self.path)
 
     def leave_chroot(self):
         assert self.inchroot

--- a/elbepack/rfs.py
+++ b/elbepack/rfs.py
@@ -15,6 +15,7 @@ from elbepack.egpg import unarmor_openpgp_keyring
 from elbepack.shellhelper import chroot, do
 from elbepack.templates import get_preseed, preseed_to_text, write_pack_template
 from elbepack.treeutils import strip_leading_whitespace_from_lines
+from elbepack.unshare import run_unshared
 
 
 def create_apt_prefs(xml, rfs):
@@ -290,7 +291,7 @@ class BuildEnv:
             cmd, keyring = self._strapcmd(arch, suite, cross, mmdebstrap)
             if keyring and self.xml.has('project/mirror/cdrom'):
                 self.convert_asc_to_gpg('/cdrom/targetrepo/repo.pub', '/elbe.keyring')
-            do(cmd)
+            run_unshared(do, cmd)
 
             if cross and not mmdebstrap:
                 ui = '/usr/share/elbe/qemu-elbe/' + self.xml.defs['userinterpr']

--- a/elbepack/rpcaptcache.py
+++ b/elbepack/rpcaptcache.py
@@ -24,6 +24,7 @@ from elbepack.aptprogress import (
     ElbeOpProgress,
 )
 from elbepack.log import async_logging
+from elbepack.unshare import unshare_inplace
 
 
 class MyMan(BaseManager):
@@ -48,11 +49,16 @@ class MyMan(BaseManager):
         sys.__stdout__ = sys.stdout  # type: ignore
         sys.__stderr__ = sys.stderr  # type: ignore
 
+    @staticmethod
+    def _init_worker(w):
+        unshare_inplace()
+        MyMan.redirect_outputs(w)
+
     def start(self):
         """Redirect outputs of the process to an async logging thread"""
         alog = async_logging()
         self.log_finalizer = Finalize(self, alog.shutdown)
-        super().start(MyMan.redirect_outputs, [alog.write_fd])
+        super().start(MyMan._init_worker, [alog.write_fd])
 
 
 class InChRootObject:

--- a/elbepack/shellhelper.py
+++ b/elbepack/shellhelper.py
@@ -10,6 +10,7 @@ import shlex
 import subprocess
 
 from elbepack.log import async_logging_ctx
+from elbepack.unshare import run_in_chroot
 
 
 """
@@ -151,17 +152,18 @@ def chroot(directory, cmd, /, *, env_add=None, **kwargs):
     subprocess.CalledProcessError: ...
     >>> cleanup()
     """
-
-    new_env = {'LANG': 'C',
-               'LANGUAGE': 'C',
-               'LC_ALL': 'C'}
-    if env_add:
-        new_env.update(env_add)
-
     if _is_shell_cmd(cmd):
-        do(['/usr/sbin/chroot', directory, '/bin/sh', '-c', cmd], env_add=new_env, **kwargs)
+        cmd = ['/bin/sh', '-c', cmd]
     else:
-        do(['/usr/sbin/chroot', directory] + cmd, env_add=new_env, **kwargs)
+        cmd = list(cmd)
+
+    def _do_cmd_in_chroot():
+        do(cmd, **kwargs)
+
+    try:
+        run_in_chroot(directory, _do_cmd_in_chroot, env_add=env_add)
+    except OSError as e:
+        raise subprocess.CalledProcessError(1, cmd) from e
 
 
 def env_add(d):

--- a/elbepack/unshare.py
+++ b/elbepack/unshare.py
@@ -1,0 +1,201 @@
+# ELBE - Debian Based Embedded Rootfilesystem Builder
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Linutronix GmbH
+
+"""
+Low-level unshare and namespace/mount primitives.
+"""
+
+import ctypes
+import grp
+import os
+import pwd
+import subprocess
+from pathlib import Path
+
+
+_CLONE_NEWUSER = 0x10000000
+_CLONE_NEWNS = 0x00020000
+
+_MS_BIND = 4096
+_MS_REC = 16384
+
+# Used to track whether the calling process has already unshared itself
+_process_unshared = False
+
+
+def _unshare(flags):
+    libc = ctypes.CDLL(None, use_errno=True)
+    if libc.unshare(flags) != 0:
+        errno = ctypes.get_errno()
+        raise OSError(errno, os.strerror(errno))
+
+
+def _read_subid_range(path, name):
+    with open(path) as f:
+        for line in f:
+            entry_name, start, count = line.strip().split(':')
+            if entry_name == name:
+                return int(start), int(count)
+    raise LookupError(f'no {path} entry for {name!r}')
+
+
+def _passthrough_id_map(current_map_content):
+    lines = []
+    for line in current_map_content.strip().splitlines():
+        inner, _outer, count = line.split()
+        lines.append(f'{inner} {inner} {count}')
+    return '\n'.join(lines) + '\n'
+
+
+def _setup_id_mapping(my_pid, as_root=False):
+    if as_root:
+        # If we are already root, we might be in one of two situations
+        #
+        # 1.) We are truely root (e.g. inside an initvm).
+        #     Strictly speaking, we would not need to unshare into new user namespace.
+        # 2.) We are inside a container where root is already mapped and does not
+        #     correspond to the true root on the host. In that case, we still lack
+        #     CAP_SYS_ADMIN, i.e. cannot mount, but can also not use --map-auto
+        #     to perform a new mapping as root. We can, however, just reuse the existing
+        #     mapping. That also does not hurt for the first situation.
+        with open('/proc/self/uid_map') as f:
+            uid_map = _passthrough_id_map(f.read())
+        with open('/proc/self/gid_map') as f:
+            gid_map = _passthrough_id_map(f.read())
+
+        Path(f'/proc/{my_pid}/uid_map').write_text(uid_map)
+        Path(f'/proc/{my_pid}/gid_map').write_text(gid_map)
+    else:
+        # As non-root, use newuidmap/newgidmap
+        uid = os.getuid()
+        gid = os.getgid()
+        username = pwd.getpwuid(uid).pw_name
+        groupname = grp.getgrgid(gid).gr_name
+
+        subuid_start, subuid_count = _read_subid_range('/etc/subuid', username)
+        subgid_start, subgid_count = _read_subid_range('/etc/subgid', groupname)
+
+        # Map root in new namespace to current user on host
+        subprocess.run(['newuidmap', str(my_pid),
+                        '0', str(uid), '1',
+                        '1', str(subuid_start), str(subuid_count)], check=True)
+        subprocess.run(['newgidmap', str(my_pid),
+                        '0', str(gid), '1',
+                        '1', str(subgid_start), str(subgid_count)], check=True)
+
+
+def unshare_inplace():
+    global _process_unshared
+
+    my_pid = os.getpid()
+    as_root = os.geteuid() == 0
+
+    ready_r, ready_w = os.pipe()
+
+    mapper_pid = os.fork()
+    if mapper_pid == 0:
+        os.close(ready_w)
+        os.read(ready_r, 1)
+        os.close(ready_r)
+        try:
+            _setup_id_mapping(my_pid, as_root=as_root)
+            os._exit(0)
+        except (OSError, subprocess.CalledProcessError, LookupError):
+            os._exit(1)
+
+    os.close(ready_r)
+
+    _unshare(_CLONE_NEWUSER)
+
+    # Signal child to set up mappings
+    os.write(ready_w, b'x')
+    os.close(ready_w)
+
+    # Wait for child to finish
+    _, status = os.waitpid(mapper_pid, 0)
+    if status != 0:
+        raise OSError('failed to set up the uid/gid mapping for the new namespace')
+
+    # Unshare mount namespace
+    _unshare(_CLONE_NEWNS)
+
+    _process_unshared = True
+
+
+def _set_c_locale():
+    os.environ['LANG'] = 'C'
+    os.environ['LANGUAGE'] = 'C'
+    os.environ['LC_ALL'] = 'C'
+
+
+def _bind_mount_pseudo_filesystems(directory):
+    if directory == '/':
+        return
+
+    libc = ctypes.CDLL(None, use_errno=True)
+    for fs in ('proc', 'sys', 'dev'):
+        src = f'/{fs}'
+        dst = os.path.join(directory, fs)
+        os.makedirs(dst, exist_ok=True)
+        ret = libc.mount(src.encode(), dst.encode(), None,
+                         ctypes.c_ulong(_MS_BIND | _MS_REC), None)
+        if ret != 0:
+            errno = ctypes.get_errno()
+            raise OSError(errno, f'mount({src!r}, {dst!r}): {os.strerror(errno)}')
+
+
+def enter_chroot_inplace(directory):
+    global _process_unshared
+    assert _process_unshared, 'Internal error: process not yet unshared'
+
+    _set_c_locale()
+
+    if directory == '/':
+        return
+
+    _bind_mount_pseudo_filesystems(directory)
+    os.chdir(directory)
+    os.chroot(directory)
+
+
+def run_in_chroot(directory, fn, *args, env_add=None, **kwargs):
+    pid = os.fork()
+    if pid == 0:
+        _set_c_locale()
+        if env_add:
+            os.environ.update(env_add)
+
+        try:
+            unshare_inplace()
+
+            if directory != '/':
+                _bind_mount_pseudo_filesystems(directory)
+                os.chdir(directory)
+                os.chroot(directory)
+
+            fn(*args, **kwargs)
+            os._exit(0)
+        except Exception:
+            os._exit(1)
+    else:
+        _, status = os.waitpid(pid, 0)
+        if status != 0:
+            raise OSError('chrooted function failed in child process')
+
+
+def run_unshared(fn, *args, **kwargs):
+    pid = os.fork()
+    if pid == 0:
+        # Child process: unshare and run the function
+        try:
+            unshare_inplace()
+            fn(*args, **kwargs)
+            os._exit(0)
+        except Exception:
+            os._exit(1)
+    else:
+        # Parent process: wait for child
+        _, status = os.waitpid(pid, 0)
+        if status != 0:
+            raise OSError('unshared function failed in child process')


### PR DESCRIPTION
This contains the patches that were previously part of https://github.com/Linutronix/elbe/pull/465 but were splitted out from there for clarity. For motivation of this patch series, see the first commit message:

    Until now, ELBE runs inside an initvm with full privileges, including
    the ability to chroot and mount to generate a new isolated environment
    for image generation.
    
    However, setting up and using an initvm requires special privileges on
    the machine and has a significant time and storage overhead.
    This is fine for builds on developer machines where the developer
    anyway has full root access, but induces complications for developers
    working on infrastructure maintained by a third-party, including cloud
    infrastructure.
    
    The goal shall be to perform ELBE builds in environments without special
    privileges, specifically including rootless containers.
    
    The solution to gain the required capabilities to execute chroot and
    mount commands is to enter a new user namespace, that gains a full set
    of capabilities, but only restricted to that namespace!
    
    With that, we can safely execute all the commands required by an ELBE
    build, confined to the created namespaces, without requiring these
    capabilities from the calling user.

