### PR TITLE
elbepack: egpg: ignore deprecation warning during gpg import

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -17,7 +17,9 @@ jobs:
       run: |
         sudo apt install mypy python3-pytest \
                 flake8 python3-flake8-quotes python3-flake8-import-order \
-                python3-gpg python3-passlib
+                python3-gpg python3-passlib python3-guestfs python3-mako \
+                python3-suds python3-sqlalchemy python3-spyne \
+                python3-pyinotify python3-pyudev
     - name: Test with pytest
       run: |
         pytest

--- a/elbepack/commands/updated.py
+++ b/elbepack/commands/updated.py
@@ -7,9 +7,12 @@ import argparse
 import os
 import signal
 import sys
+import warnings
 from wsgiref.simple_server import make_server
 
-from spyne.protocol.soap import Soap11
+with warnings.catch_warnings():
+    warnings.filterwarnings('ignore', "'cgi' is deprecated", DeprecationWarning)
+    from spyne.protocol.soap import Soap11
 from spyne.server.wsgi import WsgiApplication
 
 from elbepack.config import add_argument_soaptimeout

--- a/elbepack/egpg.py
+++ b/elbepack/egpg.py
@@ -6,10 +6,16 @@ import os
 import pathlib
 import shutil
 import subprocess
+import warnings
 
-from gpg import core
-from gpg.constants import PROTOCOL_OpenPGP, sig, sigsum
-from gpg.errors import GPGMEError, InvalidSigners, KeyNotFound
+
+with warnings.catch_warnings():
+    warnings.filterwarnings('ignore',
+                            message=r'builtin type [Ss]wig\w+ has no __module__ attribute',
+                            category=DeprecationWarning)
+    from gpg import core
+    from gpg.constants import PROTOCOL_OpenPGP, sig, sigsum
+    from gpg.errors import GPGMEError, InvalidSigners, KeyNotFound
 
 from elbepack.shellhelper import env_add
 

--- a/elbepack/tests/test_import.py
+++ b/elbepack/tests/test_import.py
@@ -1,0 +1,24 @@
+# ELBE - Debian Based Embedded Rootfilesystem Builder
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Linutronix GmbH
+
+import importlib
+import pkgutil
+
+import pytest
+
+import elbepack
+
+modules = [
+    module.name
+    for module in pkgutil.walk_packages(elbepack.__path__, elbepack.__name__ + '.')
+    if not module.name.endswith('.__main__')
+]
+
+
+@pytest.mark.parametrize('module', modules)
+def test_import(module):
+    try:
+        importlib.import_module(module)
+    except ImportError:
+        pass


### PR DESCRIPTION
Currently, the Python GPG library throws a deprecation warning. Together
with -Werror (as it is default for our pytest setup), this warning gets
escalated into a exception and thus the import fails.
    
Wrap the import to avoid this behavior.

Also add a test to ensure similar cases do not occur in the future.