### PR TITLE
Ensure SOAP daemon is both started and stopped properly

### DIFF
--- a/elbepack/asyncworker.py
+++ b/elbepack/asyncworker.py
@@ -299,6 +299,7 @@ class AsyncWorker(Thread):
         while True:
             job = self.queue.get()
             if job is None:
+                self.queue.task_done()
                 break
 
             os.chdir('/')

--- a/elbepack/commands/daemon.py
+++ b/elbepack/commands/daemon.py
@@ -41,6 +41,10 @@ class _ElbeWSGIRequestHandler(wsgiref.simple_server.WSGIRequestHandler):
         pass  # Noop
 
 
+class _ReusePortWSGIServer(wsgiref.simple_server.WSGIServer):
+    allow_reuse_address = True
+
+
 def get_daemonlist():
     return [x for _, x, _ in iter_modules(elbepack.daemons.__path__)]
 
@@ -92,6 +96,7 @@ def run_command(argv):
 
         with wsgiref.simple_server.make_server(
                 args.host, args.port, dispatcher,
+                server_class=_ReusePortWSGIServer,
                 handler_class=_ElbeWSGIRequestHandler,
         ) as httpd:
             _sd_notify(b'READY=1\n'

--- a/elbepack/daemons/soap/__init__.py
+++ b/elbepack/daemons/soap/__init__.py
@@ -32,10 +32,19 @@ class EsoapApp(Application):
         self.pm.stop()
 
 
+class StopableWsgiApplication(WsgiApplication):
+    def __init__(self, app):
+        self._app = app
+        super().__init__(app)
+
+    def stop(self):
+        self._app.stop()
+
+
 def get_app():
 
     app = EsoapApp([ESoap], 'soap',
                    in_protocol=Soap11(validator='lxml'),
                    out_protocol=Soap11())
 
-    return WsgiApplication(app)
+    return StopableWsgiApplication(app)


### PR DESCRIPTION
elbepack: allow reuse of address
Set SO_REUSEADDR for the WSGI server. This allows for quicker restart of
the server and should have no negative impact since in our context (i.e.
either in initvm or inside the container) there should not be other
competing servers.

elbepack: soap: restore stop method accessibility
Commit https://github.com/Linutronix/elbe/commit/a747152fc2156e07bf58e7c9e78c02567311834e ("elbepack: soap: remove beaker middleware") removed
the MySession wrapper class that provided access to the stop method.
This caused the daemon management code to no longer find and execute
the stop method during shutdown.

This restores the proper shutdown behavior where the stop method is
called during daemon termination.

Also, the stop of the AsyncWorker was never finalized because join
waited for task_done after pushing None.

Fixes: https://github.com/Linutronix/elbe/commit/a747152fc2156e07bf58e7c9e78c02567311834e ("elbepack: soap: remove beaker middleware")
