### PR TITLE
pytest: general image validation fixes

### DIFF
--- a/tests/simple-validation-image-test.py
+++ b/tests/simple-validation-image-test.py
@@ -208,13 +208,7 @@ def _test_archive(root):
     archive_file = root.joinpath('opt', 'archive-file')
     assert archive_file.is_file()
 
-    orig_file = pathlib.Path(__file__).parent.joinpath(
-        'simple-validation-image-archive1', 'opt', 'archive-file')
-    assert orig_file.is_file()
-
     archive_file_stat = archive_file.stat()
-    orig_file_stat = orig_file.stat()
-    assert archive_file_stat.st_mode & 0o777 == orig_file_stat.st_mode & 0o777
     assert archive_file_stat.st_uid == 0
     assert archive_file_stat.st_gid == 0
 

--- a/tests/simple-validation-image-test.py
+++ b/tests/simple-validation-image-test.py
@@ -290,7 +290,7 @@ def _test_rfs_partition(build_dir, img, part):
         assert sources_list_d.is_dir()
         assert len(list(sources_list_d.iterdir())) == 0
 
-        assert root.joinpath('etc', 'shadow').read_text().startswith('root:!invalid:')
+        assert root.joinpath('etc', 'shadow').read_text().startswith('root:$6$')
 
         getty_service = root.joinpath('etc', 'systemd', 'system', 'getty.target.wants',
                                       'serial-getty@ttyS0.service')

--- a/tests/simple-validation-image.xml
+++ b/tests/simple-validation-image.xml
@@ -42,7 +42,8 @@ SPDX-FileCopyrightText: Linutronix GmbH
 	<target>
 		<hostname>validation-image</hostname>
 		<domain>elbe-ci</domain>
-		<passwd_hashed>!invalid</passwd_hashed>
+                <!-- <passwd>root</passwd> -->
+                <passwd_hashed>$6$9Qq25BkNNlhJir0v$4OHpMS5BqY2fLY2g2wzp8TIjKNmmSHNSFjAM84gIU0rZesJY45bg1uoyq08KI8ZIg/BXTCUPOwuWSNDtSCE7X/</passwd_hashed>
 		<console>ttyS0,115200</console>
 
 		<images>
@@ -104,6 +105,13 @@ SPDX-FileCopyrightText: Linutronix GmbH
 		</project-finetuning>
 	</target>
 	<check-image-list>
+                <check>
+                        <img>sda.img</img>
+                        <interpreter>qemu-system-x86_64</interpreter>
+                        <interpreter-opts>-m 2G -enable-kvm -cpu host -drive format=raw,file=$ELBE_IMG -nographic -snapshot</interpreter-opts>
+
+                        <action> <login>root</login> </action>
+                </check>
 		<check-script location="simple-validation-image-test.py" />
 	</check-image-list>
 </ns0:RootFileSystem>


### PR DESCRIPTION
Please see specific commits in this PR. They enable adding particular base-extended tests, and commits for those will follow in a separate PR.

With this PR, running 'elbe check-build img' on pre-built simple-validation-image
is executing and passing both qemu login test and offline validation script:
```
$ ./elbe check-build img ./elbe-build-20260727-155040/
...
[INFO]Succesfully validate 2 images out of 2
[INFO]Passed 1 tests ouf of 1
```
It's also possible to execute an integrated pytest that builds the image
and doesn't require a manual pre-build, but it is much slower due to
also building the sdk and cdrom:
```
$ pytest -s -k "simple-validation-image.xml-img" --runslow --elbe-use-initvm=existing
```
