### PR TITLE
Further preparing the testing infrastructure for base image tarballs

### DIFF
--- a/elbevalidate/path.py
+++ b/elbevalidate/path.py
@@ -220,3 +220,62 @@ class ImagePath(Path):
             stat['files'], stat['ffree'], stat['favail'],
             stat['fsid'], stat['flag'], stat['namemax'],
         ])
+
+
+class TarballPath(Path):
+    """
+    Reference to a path inside a :py:class:`tarfile.TarFile`.
+
+    For documentation see :py:mod:`pathlib`.
+    """
+    def __init__(self, *pathsegments, tar):
+        self.tar = tar
+        self._p = pathlib.PurePosixPath(*pathsegments)
+
+    def _create_from_posixpath(self, p):
+        return type(self)(
+                p,
+                tar=self.tar,
+        )
+
+    def _info(self):
+        try:
+            member = self.tar.getmember(self._path)
+        except KeyError:
+            member = self.tar.getmember('./' + self._path)
+        return member
+
+    def read_bytes(self):
+        with self.tar.extractfile(self._info()) as f:
+            bytes = f.read()
+        return bytes
+
+    def exists(self):
+        try:
+            self._info()
+        except KeyError:
+            return False
+        return True
+
+    def is_file(self):
+        return self._info().isfile()
+
+    def stat(self):
+        info = self._info()
+        return os.stat_result((
+            info.mode, 0, 0, 0, info.uid, info.gid, info.size, info.mtime, info.mtime, info.mtime))
+
+    def is_dir(self):
+        return self._info().isdir()
+
+    def iterdir(self):
+        dir = os.path.normpath(self._path)
+        for entry in self.tar.getnames():
+            if os.path.normpath(os.path.dirname(entry)) == dir:
+                yield self._create_from_posixpath(entry)
+
+    def is_symlink(self):
+        return self._info().issym()
+
+    def readlink(self):
+        return self._info().linkname

--- a/test/test_elbevalidate.py
+++ b/test/test_elbevalidate.py
@@ -4,10 +4,13 @@
 
 import pathlib
 import subprocess
+import tarfile
 import tempfile
 import textwrap
 
 from elbepack.tests.test_helpers import make_disk
+
+from elbevalidate.path import TarballPath
 
 
 def _make_partition(path):
@@ -90,3 +93,56 @@ def test_elbevalidate(elbevalidate, tmp_path):
             assert root.joinpath('foo').exists()
             assert not root.joinpath('bar').exists()
             assert root.joinpath('data', 'bar').exists()
+
+
+def test_tarbpallpath(tmp_path):
+    def _check_dir(dir):
+        dir_content = [str(i) for i in dir.iterdir()]
+        assert '{}/test-file'.format(dir) in dir_content
+        assert '{}/test-link'.format(dir) in dir_content
+
+        test_file = dir / 'test-file'
+        assert test_file.exists()
+        assert test_file.is_file()
+        assert not test_file.is_dir()
+        assert not test_file.is_symlink()
+        assert test_file.stat().st_size == 12
+        assert test_file.read_bytes() == b'Test content'
+
+        test_link = dir / 'test-link'
+        assert test_link.exists()
+        assert not test_link.is_file()
+        assert not test_link.is_dir()
+        assert test_link.is_symlink()
+        assert test_link.readlink() == 'test-file'
+
+    tarball = tmp_path / 'test-tarball.tar'
+
+    tarball_dir = tmp_path / 'tarball-dir'
+    tarball_dir.mkdir()
+
+    tarball_dir.joinpath('test-file').write_text('Test content')
+    tarball_dir.joinpath('test-link').symlink_to('test-file')
+
+    with tarfile.open(tarball, 'w') as tar:
+        tar.add(tarball_dir, arcname='dir1')
+        tar.add(tarball_dir, arcname='./dir2')
+
+    with tarfile.open(tarball) as tar:
+        tbpath = TarballPath(tar=tar)
+
+        top_dirs = [str(i) for i in tbpath.iterdir()]
+        assert 'dir1' in top_dirs
+        assert 'dir2' in top_dirs
+
+        dir1 = tbpath / 'dir1'
+        assert dir1.exists()
+        assert dir1.is_dir()
+        dir2 = tbpath / 'dir2'
+        assert dir2.exists()
+        assert dir2.is_dir()
+        dir3 = tbpath / 'dir3'
+        assert not dir3.exists()
+
+        _check_dir(dir1)
+        _check_dir(dir2)


### PR DESCRIPTION
There are two commits here: one is adding a test fixture to pass the project name into tests, so they know what is being tested, another adds a tarball implementation for inspecting the root filesystems. Please see the commit messages for details.