### PR TITLE
elbepack/log.py: use info logging level by default instead of debugging

### DIFF
--- a/elbepack/log.py
+++ b/elbepack/log.py
@@ -159,7 +159,7 @@ def elbe_logging(*args, **kwargs):
 
 
 def open_logging(**targets):
-    root.setLevel(logging.DEBUG)
+    root.setLevel(logging.INFO)
 
     handlers = []
 


### PR DESCRIPTION
Debugging level should never be set by default and should always be an explicit opt-in via a command line option or an environment variable. The reason is that depending on what logging handlers are set up, and how big the debugging output is for particular code paths, the sheer volume of text can overwhelm the machine or the network.

The particular issue here is pytest, which sets up its own handlers for logging that *capture all of the logging in RAM* while the test is running. When pytest performs a base image (or cdrom) upload to initvm, which sends chunks of data to the external binascii module, said module logs lots of debugging *for each chunk*. This quickly exhausts the RAM on my laptop, which is a not-unreasonable 16G.