### PR TITLE
.github/workflows/pytest.yml: run 'apt update' before installation

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: Install dependencies
       run: |
-        sudo apt install mypy python3-pytest \
+        sudo apt update && sudo apt install mypy python3-pytest \
                 flake8 python3-flake8-quotes python3-flake8-import-order \
                 python3-gpg python3-passlib python3-guestfs python3-mako \
                 python3-suds python3-sqlalchemy python3-spyne \


### PR DESCRIPTION
There have been annoying pipeline errors which seem to result from not having the most up to date package cache.